### PR TITLE
ofac: bump minimum threshold to 99% matches

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The following environmental variables can be set to configure behavior in Accoun
 | `HTTPS_CERT_FILE` | Filepath containing a certificate (or intermediate chain) to be served by the HTTP server. Requires all traffic be over secure HTTP. | Empty |
 | `HTTPS_KEY_FILE`  | Filepath of a private key matching the leaf certificate from `HTTPS_CERT_FILE`. | Empty |
 | `OFAC_ENDPOINT` | HTTP address for [OFAC](https://github.com/moov-io/ofac) interaction, defaults to Kubernetes inside clusters and local dev otherwise. | Kubernetes DNS |
-| `OFAC_MATCH_THRESHOLD` | Percent match against OFAC data that's required for paygate to block a transaction. | `0.90` |
+| `OFAC_MATCH_THRESHOLD` | Percent match against OFAC data that's required for paygate to block a transaction. | `99%` |
 | `DATABASE_TYPE` | Which database option to use (Options: `sqlite`, `mysql`) | Default: `sqlite` |
 
 #### Storage

--- a/cmd/server/approval.go
+++ b/cmd/server/approval.go
@@ -29,7 +29,7 @@ var (
 				return float32(f)
 			}
 		}
-		return 0.90 // default, 90%
+		return 0.99 // default, 99%
 	}()
 
 	errNoAddressId = errors.New("no Address ID found")


### PR DESCRIPTION
After upgrading to v0.11.0 OFAC's search and ranking has been improved
so we need to be less tolerant of low quality matches.