### PR TITLE
cmd/server: allow email, phones, and addresses to be optional on a Customer

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -113,7 +113,7 @@ func main() {
 	}
 
 	// Register our admin routes
-	addApprovalRoutes(logger, adminServer, customerRepo, ofac)
+	addApprovalRoutes(logger, adminServer, customerRepo, customerSSNRepo, ofac)
 	addDisclaimerAdminRoutes(logger, adminServer, disclaimerRepo, documentRepo)
 
 	// Setup Customer SSN storage wrapper


### PR DESCRIPTION
Creating a customer might involve adding data in several steps. This is the case with paygate where initially there isn't enough information to always create a Customer. In the case of a Receiver there's no SSN to attach (and one isn't needed to push money at a Receiver).

Let's loosen the requirements for a Customer and verify the data when status transitions happen. 

Issue: https://github.com/moov-io/paygate/issues/98