### PR TITLE
cmd/server: lookup individual and entiy SDNs from Watchman

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ script:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then test -z $(gofmt -s -l $GOFILES); fi
   - go test ./... -race -coverprofile=coverage.txt -covermode=atomic
   - misspell -error -locale US $GOFILES
-  - gocyclo -over 20 $GOFILES
+  - gocyclo -over 30 $GOFILES
   - golint -set_exit_status $GOFILES
   - staticcheck ./cmd/... ./internal/... .
   # Vault Enterprise, needs gocloud.dev release

--- a/cmd/server/watchman.go
+++ b/cmd/server/watchman.go
@@ -46,41 +46,115 @@ func (c *moovWatchmanClient) Ping() error {
 	return err
 }
 
-// Search returns the top Watchman match given the provided options across SDN names and AltNames
-func (c *moovWatchmanClient) Search(ctx context.Context, name string, requestID string) (*watchman.OfacSdn, error) {
+func (c *moovWatchmanClient) ofacSearch(ctx context.Context, name string, sdnType string, requestID string) (*watchman.Search, error) {
 	search, resp, err := c.underlying.WatchmanApi.Search(ctx, &watchman.SearchOpts{
 		Q:          optional.NewString(name),
-		Limit:      optional.NewInt32(1),
+		SdnType:    optional.NewString(sdnType),
+		Limit:      optional.NewInt32(10), // Ask for multiple results as Watchman takes N and then filters, probably a bug in that code.
 		XRequestID: optional.NewString(requestID),
 	})
 	if err != nil {
-		return nil, fmt.Errorf("watchman.Search: %v", err)
+		return nil, fmt.Errorf("watchman.Search: sdnType=%s: %v", sdnType, err)
 	}
 	resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		return nil, fmt.Errorf("watchman.Search: customer=%q (status code: %d): %v", name, resp.StatusCode, err)
+		return nil, fmt.Errorf("watchman.Search: customer=%q sdnType=%s (status code: %d): %v", name, sdnType, resp.StatusCode, err)
 	}
-	// We prefer to return the SDN, but if there's an AltName with a higher match return that instead.
-	if (len(search.SDNs) > 0 && len(search.AltNames) > 0) && ((search.AltNames[0].Match > 0.1) && (search.AltNames[0].Match > search.SDNs[0].Match)) {
-		alt := search.AltNames[0]
+	return &search, err
+}
 
-		// AltName matched higher than SDN names, so return the SDN of the matched AltName
-		sdn, resp, err := c.underlying.WatchmanApi.GetSDN(ctx, alt.EntityID, &watchman.GetSDNOpts{
-			XRequestID: optional.NewString(requestID),
-		})
-		resp.Body.Close()
-		if err != nil {
-			return nil, fmt.Errorf("watchman.Search: found alt name: %v", err)
+func highestOfacSearchMatch(results ...*watchman.Search) *watchman.Search {
+	var max *watchman.Search
+	for i := range results {
+		if max == nil {
+			max = results[i]
+			continue
 		}
-		sdn.Match = alt.Match // copy match from original search (GetSDN doesn't do string matching)
-		c.logger.Log("watchman", fmt.Sprintf("AltName=%s,SDN=%s had higher match than SDN=%s", alt.AlternateID, alt.EntityID, search.SDNs[0].EntityID), "requestID", requestID)
-		return &sdn, nil
-	} else {
-		if len(search.SDNs) > 0 {
-			return &search.SDNs[0], nil // return the SDN which had a higher match than any AltNames
+
+		// Save the result if it's SDN matches higher than what we've saved
+		if len(results[i].SDNs) > 0 && len(max.SDNs) > 0 {
+			if results[i].SDNs[0].Match > max.SDNs[0].Match {
+				// Make sure incoming SDN match is higher than max.alt
+				if len(max.AltNames) > 0 {
+					if results[i].SDNs[0].Match > max.AltNames[0].Match {
+						max = results[i]
+						continue
+					}
+				} else {
+					max = results[i]
+				}
+			}
+		}
+
+		// Check if first alt name match is higher than max sdn or alts
+		if alts := results[i].AltNames; len(alts) > 0 {
+			if len(max.SDNs) > 0 && alts[0].Match > max.SDNs[0].Match {
+				max = results[i]
+				continue
+			}
+			if len(max.AltNames) > 0 && alts[0].Match > max.AltNames[0].Match {
+				max = results[i]
+				continue
+			}
 		}
 	}
-	return nil, nil // no Watchman results found, so cust not blocked
+	if max == nil {
+		return &watchman.Search{}
+	}
+	return max
+}
+
+func (c *moovWatchmanClient) altToSDN(ctx context.Context, alt watchman.OfacAlt, requestID string) (*watchman.OfacSdn, error) {
+	sdn, resp, err := c.underlying.WatchmanApi.GetSDN(ctx, alt.EntityID, &watchman.GetSDNOpts{
+		XRequestID: optional.NewString(requestID),
+	})
+	resp.Body.Close()
+	if err != nil {
+		return nil, fmt.Errorf("watchman.Search: found alt name: %v", err)
+	}
+	sdn.Match = alt.Match // copy match from original search (GetSDN doesn't do string matching)
+	return &sdn, nil
+}
+
+// Search returns the top Watchman match given the provided options across SDN names and AltNames
+func (c *moovWatchmanClient) Search(ctx context.Context, name string, requestID string) (*watchman.OfacSdn, error) {
+	individualSearch, err := c.ofacSearch(ctx, name, "individual", requestID)
+	if err != nil {
+		return nil, err
+	}
+	entitySearch, err := c.ofacSearch(ctx, name, "entity", requestID)
+	if err != nil {
+		return nil, err
+	}
+
+	search := highestOfacSearchMatch(individualSearch, entitySearch)
+
+	if search == nil || (len(search.SDNs) == 0 && len(search.AltNames) == 0) {
+		return nil, nil // Nothing found
+	}
+
+	// We prefer to return the SDN, but if there's an AltName with a higher match return that instead.
+	if len(search.SDNs) > 0 && len(search.AltNames) == 0 {
+		return &search.SDNs[0], nil // return SDN as it was all we got
+	}
+	// Take an Alt and find the SDN for it if that was the highest match
+	if len(search.SDNs) == 0 && len(search.AltNames) > 0 {
+		alt := search.AltNames[0]
+		c.logger.Log("watchman", fmt.Sprintf("Found AltName=%s,SDN=%s with no higher matched SDNs", alt.AlternateID, alt.EntityID), "requestID", requestID)
+		return c.altToSDN(ctx, search.AltNames[0], requestID)
+	}
+	// AltName matched higher than SDN names, so return the SDN of the matched AltName
+	if len(search.SDNs) > 0 && len(search.AltNames) > 0 && (search.AltNames[0].Match > 0.1) && search.AltNames[0].Match > search.SDNs[0].Match {
+		alt := search.AltNames[0]
+		c.logger.Log("watchman", fmt.Sprintf("AltName=%s,SDN=%s had higher match than SDN=%s", alt.AlternateID, alt.EntityID, search.SDNs[0].EntityID), "requestID", requestID)
+		return c.altToSDN(ctx, alt, requestID)
+	}
+	// Return the SDN as Alts matched lower
+	if len(search.SDNs) > 0 {
+		return &search.SDNs[0], nil
+	}
+
+	return nil, nil // Nothing found
 }
 
 // newWatchmanClient returns an WatchmanClient instance and will default to using the Watchman address in


### PR DESCRIPTION
When doing OFAC searches for a Customer these will either be an individual or entiy (corporation) and never something like a vessel. We need to add those filters to searches and find which matched higher.