### PR TITLE
Account holder OFAC search using HolderName

### DIFF
--- a/api/client.yaml
+++ b/api/client.yaml
@@ -515,6 +515,52 @@ paths:
             application/json:
               schema:
                 $ref: 'https://raw.githubusercontent.com/moov-io/api/master/openapi-common.yaml#/components/schemas/Error'
+  /customers/{customerID}/accounts/{accountID}/ofac:
+    get:
+      tags: [ Customers ]
+      summary: Get latest OFAC search
+      description: Get the latest OFAC search for an account
+      operationId: getLatestAccountOFACSearch
+      parameters:
+        - name: X-Request-ID
+          in: header
+          description: Optional requestID allows application developer to trace requests through the systems logs
+          example: rs4f9915
+          schema:
+            type: string
+        - name: X-User-ID
+          in: header
+          description: Unique userID set by an auth proxy or client to identify and isolate objects.
+          example: e3cdf999
+          schema:
+            type: string
+        - name: customerID
+          in: path
+          description: customerID of the Customer
+          required: true
+          schema:
+            type: string
+            example: e210a9d6
+        - name: accountID
+          in: path
+          description: accountID of the Account to get latest OFAC search
+          required: true
+          schema:
+            type: string
+            example: e210a9d6
+      responses:
+        '200':
+          description: OFAC search did not block account
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OFACSearch'
+        '400':
+          description: An error occurred when refreshing OFAC data, see error(s)
+          content:
+            application/json:
+              schema:
+                $ref: 'https://raw.githubusercontent.com/moov-io/api/master/openapi-common.yaml#/components/schemas/Error'
   /customers/{customerID}/disclaimers:
     get:
       tags: [Customers]

--- a/cmd/server/accounts/accounts_ofac.go
+++ b/cmd/server/accounts/accounts_ofac.go
@@ -1,0 +1,61 @@
+package accounts
+
+import (
+	"context"
+	"fmt"
+	"github.com/moov-io/customers/pkg/client"
+	watchman "github.com/moov-io/watchman/client"
+	"github.com/pkg/errors"
+	"time"
+)
+
+type ofacSearchResult struct {
+	EntityID  string    `json:"entityID"`
+	SDNName   string    `json:"sdnName"`
+	SDNType   string    `json:"sdnType"`
+	Match     float32   `json:"match"`
+	CreatedAt time.Time `json:"createdAt"`
+}
+
+type AccountOfacSearcher struct {
+	Repo           Repository
+	WatchmanClient WatchmanClient
+}
+
+type WatchmanClient interface {
+	Ping() error
+
+	Search(ctx context.Context, name string, requestID string) (*watchman.OfacSdn, error)
+}
+
+// StoreAccountOFACSearch performs OFAC searches against the Account's HolderName and nickname if populated.
+// The higher matching search result is stored in s.customerRepository for use later (in approvals)
+func (s *AccountOfacSearcher) StoreAccountOFACSearch(account *client.Account, requestID string) error {
+	ctx, cancelFn := context.WithTimeout(context.TODO(), 10*time.Second)
+	defer cancelFn()
+
+	if account == nil {
+		return errors.New("nil account")
+	}
+
+	if account.HolderName == "" {
+		return errors.New("no account HolderName to perform check with")
+	}
+
+	sdn, err := s.WatchmanClient.Search(ctx, account.HolderName, requestID)
+	if err != nil {
+		return fmt.Errorf("AccountOfacSearcher.StoreAccountOFACSearch: name search for account=%s: %v", account.AccountID, err)
+	}
+	err = s.Repo.SaveAccountOFACSearch(account.AccountID, ofacSearchResult{
+		EntityID:  sdn.EntityID,
+		SDNName:   sdn.SdnName,
+		SDNType:   sdn.SdnType,
+		Match:     sdn.Match,
+		CreatedAt: time.Now(),
+	})
+	if err != nil {
+		return fmt.Errorf("AccountOfacSearcher.StoreAccountOFACSearch: SaveAccountOFACSearch account=%s: %v", account.AccountID, err)
+	}
+
+	return nil
+}

--- a/cmd/server/accounts/accounts_ofac.go
+++ b/cmd/server/accounts/accounts_ofac.go
@@ -9,14 +9,6 @@ import (
 	"time"
 )
 
-type ofacSearchResult struct {
-	EntityID  string    `json:"entityID"`
-	SDNName   string    `json:"sdnName"`
-	SDNType   string    `json:"sdnType"`
-	Match     float32   `json:"match"`
-	CreatedAt time.Time `json:"createdAt"`
-}
-
 type AccountOfacSearcher struct {
 	Repo           Repository
 	WatchmanClient WatchmanClient
@@ -46,10 +38,10 @@ func (s *AccountOfacSearcher) StoreAccountOFACSearch(account *client.Account, re
 	if err != nil {
 		return fmt.Errorf("AccountOfacSearcher.StoreAccountOFACSearch: name search for account=%s: %v", account.AccountID, err)
 	}
-	err = s.Repo.saveAccountOFACSearch(account.AccountID, ofacSearchResult{
+	err = s.Repo.saveAccountOFACSearch(account.AccountID, &client.OfacSearch{
 		EntityID:  sdn.EntityID,
-		SDNName:   sdn.SdnName,
-		SDNType:   sdn.SdnType,
+		SdnName:   sdn.SdnName,
+		SdnType:   sdn.SdnType,
 		Match:     sdn.Match,
 		CreatedAt: time.Now(),
 	})

--- a/cmd/server/accounts/accounts_ofac.go
+++ b/cmd/server/accounts/accounts_ofac.go
@@ -46,7 +46,7 @@ func (s *AccountOfacSearcher) StoreAccountOFACSearch(account *client.Account, re
 	if err != nil {
 		return fmt.Errorf("AccountOfacSearcher.StoreAccountOFACSearch: name search for account=%s: %v", account.AccountID, err)
 	}
-	err = s.Repo.SaveAccountOFACSearch(account.AccountID, ofacSearchResult{
+	err = s.Repo.saveAccountOFACSearch(account.AccountID, ofacSearchResult{
 		EntityID:  sdn.EntityID,
 		SDNName:   sdn.SdnName,
 		SDNType:   sdn.SdnType,
@@ -54,7 +54,7 @@ func (s *AccountOfacSearcher) StoreAccountOFACSearch(account *client.Account, re
 		CreatedAt: time.Now(),
 	})
 	if err != nil {
-		return fmt.Errorf("AccountOfacSearcher.StoreAccountOFACSearch: SaveAccountOFACSearch account=%s: %v", account.AccountID, err)
+		return fmt.Errorf("AccountOfacSearcher.StoreAccountOFACSearch: saveAccountOFACSearch account=%s: %v", account.AccountID, err)
 	}
 
 	return nil

--- a/cmd/server/accounts/mock_repository.go
+++ b/cmd/server/accounts/mock_repository.go
@@ -15,11 +15,11 @@ type mockRepository struct {
 	Err           error
 }
 
-func (r *mockRepository) getLatestAccountOFACSearch(accountID string) (*ofacSearchResult, error) {
+func (r *mockRepository) getLatestAccountOFACSearch(accountID string) (*client.OfacSearch, error) {
 	panic("implement me")
 }
 
-func (r *mockRepository) saveAccountOFACSearch(id string, result ofacSearchResult) error {
+func (r *mockRepository) saveAccountOFACSearch(id string, result *client.OfacSearch) error {
 	panic("implement me")
 }
 

--- a/cmd/server/accounts/mock_repository.go
+++ b/cmd/server/accounts/mock_repository.go
@@ -19,7 +19,7 @@ func (r *mockRepository) getLatestAccountOFACSearch(accountID string) (*ofacSear
 	panic("implement me")
 }
 
-func (r *mockRepository) SaveAccountOFACSearch(id string, result ofacSearchResult) error {
+func (r *mockRepository) saveAccountOFACSearch(id string, result ofacSearchResult) error {
 	panic("implement me")
 }
 

--- a/cmd/server/accounts/mock_repository.go
+++ b/cmd/server/accounts/mock_repository.go
@@ -15,6 +15,14 @@ type mockRepository struct {
 	Err           error
 }
 
+func (r *mockRepository) getLatestAccountOFACSearch(accountID string) (*ofacSearchResult, error) {
+	panic("implement me")
+}
+
+func (r *mockRepository) SaveAccountOFACSearch(id string, result ofacSearchResult) error {
+	panic("implement me")
+}
+
 func (r *mockRepository) getCustomerAccount(customerID, accountID string) (*client.Account, error) {
 	if r.Err != nil {
 		return nil, r.Err

--- a/cmd/server/accounts/repository.go
+++ b/cmd/server/accounts/repository.go
@@ -174,14 +174,14 @@ func (r *sqlAccountRepository) getLatestAccountOFACSearch(accountID string) (*cl
 	defer stmt.Close()
 
 	row := stmt.QueryRow(accountID)
-	var res *client.OfacSearch
+	var res client.OfacSearch
 	if err := row.Scan(&res.EntityID, &res.SdnType, &res.SdnType, &res.Match, &res.CreatedAt); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, nil // nothing found
 		}
 		return nil, fmt.Errorf("getLatestAccountOFACSearch: scan: %v", err)
 	}
-	return res, nil
+	return &res, nil
 }
 
 func (r *sqlAccountRepository) saveAccountOFACSearch(accountID string, result *client.OfacSearch) error {

--- a/cmd/server/accounts/repository_test.go
+++ b/cmd/server/accounts/repository_test.go
@@ -141,7 +141,7 @@ func TestRepository__updateAccountStatus(t *testing.T) {
 func TestRepositoryUnique(t *testing.T) {
 	keeper := secrets.TestStringKeeper(t)
 
-	check := func(t *testing.T, repo *sqlAccountRepository) {
+	check := func(t *testing.T, repo *SqlAccountRepository) {
 		customerID, userID := base.ID(), base.ID()
 		req := &createAccountRequest{
 			AccountNumber: "156421",

--- a/cmd/server/accounts/repository_test.go
+++ b/cmd/server/accounts/repository_test.go
@@ -141,7 +141,7 @@ func TestRepository__updateAccountStatus(t *testing.T) {
 func TestRepositoryUnique(t *testing.T) {
 	keeper := secrets.TestStringKeeper(t)
 
-	check := func(t *testing.T, repo *SqlAccountRepository) {
+	check := func(t *testing.T, repo *sqlAccountRepository) {
 		customerID, userID := base.ID(), base.ID()
 		req := &createAccountRequest{
 			AccountNumber: "156421",

--- a/cmd/server/accounts/router_test.go
+++ b/cmd/server/accounts/router_test.go
@@ -184,7 +184,7 @@ func TestRoutes__EmptyAccounts(t *testing.T) {
 	keeper := secrets.TestStringKeeper(t)
 
 	handler := mux.NewRouter()
-	RegisterRoutes(log.NewNopLogger(), handler, repo, testFedClient, testPayGateClient, keeper, keeper, nil)
+	RegisterRoutes(log.NewNopLogger(), handler, repo, testFedClient, testPayGateClient, keeper, keeper, createTestOFACSearcher(repo, nil))
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", fmt.Sprintf("/customers/%s/accounts", customerID), nil)

--- a/cmd/server/accounts/validate_test.go
+++ b/cmd/server/accounts/validate_test.go
@@ -35,7 +35,7 @@ func TestRouter__ValidateAccounts(t *testing.T) {
 	}
 
 	handler := mux.NewRouter()
-	RegisterRoutes(log.NewNopLogger(), handler, repo, testFedClient, paygateClient, keeper, keeper)
+	RegisterRoutes(log.NewNopLogger(), handler, repo, testFedClient, paygateClient, keeper, keeper, nil)
 
 	// create account
 	acct, err := repo.createCustomerAccount(customerID, userID, &createAccountRequest{

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -164,7 +164,11 @@ func main() {
 	router := mux.NewRouter()
 	moovhttp.AddCORSHandler(router)
 	addPingRoute(router)
-	accounts.RegisterRoutes(logger, router, accountsRepo, fedClient, paygateClient, stringKeeper, transitStringKeeper)
+	accountOfacSeacher := accounts.AccountOfacSearcher{
+		Repo: accountsRepo, WatchmanClient: watchmanClient,
+	}
+	accounts.RegisterRoutes(
+		logger, router, accountsRepo, fedClient, paygateClient, stringKeeper, transitStringKeeper, &accountOfacSeacher)
 	addCustomerRoutes(logger, router, customerRepo, customerSSNStorage, ofac)
 	addDisclaimerRoutes(logger, router, disclaimerRepo)
 	addDocumentRoutes(logger, router, documentRepo, getBucket(bucketName, cloudProvider, signer))

--- a/cmd/server/route/customers.go
+++ b/cmd/server/route/customers.go
@@ -15,12 +15,22 @@ import (
 
 var (
 	ErrNoCustomerID = errors.New("no Customer ID found")
+	ErrNoAccountID  = errors.New("no Account ID found")
 )
 
 func GetCustomerID(w http.ResponseWriter, r *http.Request) string {
 	v, ok := mux.Vars(r)["customerID"]
 	if !ok || v == "" {
 		moovhttp.Problem(w, ErrNoCustomerID)
+		return ""
+	}
+	return v
+}
+
+func GetAccountID(w http.ResponseWriter, r *http.Request) string {
+	v, ok := mux.Vars(r)["accountID"]
+	if !ok || v == "" {
+		moovhttp.Problem(w, ErrNoAccountID)
 		return ""
 	}
 	return v

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/ory/dockertest/v3 v3.6.0
 	github.com/pierrec/lz4 v2.5.2+incompatible // indirect
+	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.7.1
 	github.com/prometheus/common v0.13.0 // indirect
 	github.com/stretchr/testify v1.6.1

--- a/internal/database/mysql.go
+++ b/internal/database/mysql.go
@@ -80,6 +80,10 @@ var (
 			`create table if not exists accounts(account_id varchar(40) primary key, customer_id varchar(40), user_id varchar(40), encrypted_account_number varchar(40), hashed_account_number varchar(40), masked_account_number varchar(15), routing_number varchar(10), status varchar(12), type varchar(12), created_at datetime, deleted_at datetime);`,
 		),
 		execsql(
+			"create_account_ofac_searches",
+			`create table if not exists account_ofac_searches(account_ofac_search_id varchar(40) primary key, account_id varchar(40), entity_id varchar(40), sdn_name varchar(40), sdn_type integer, percentage_match double precision (5,2), created_at datetime);`,
+		),
+		execsql(
 			"alter_customers_status",
 			`alter table customers modify status varchar(20);`,
 		),

--- a/internal/database/mysql.go
+++ b/internal/database/mysql.go
@@ -80,10 +80,6 @@ var (
 			`create table if not exists accounts(account_id varchar(40) primary key, customer_id varchar(40), user_id varchar(40), encrypted_account_number varchar(40), hashed_account_number varchar(40), masked_account_number varchar(15), routing_number varchar(10), status varchar(12), type varchar(12), created_at datetime, deleted_at datetime);`,
 		),
 		execsql(
-			"create_account_ofac_searches",
-			`create table if not exists account_ofac_searches(account_ofac_search_id varchar(40) primary key, account_id varchar(40), entity_id varchar(40), sdn_name varchar(40), sdn_type integer, percentage_match double precision (5,2), created_at datetime);`,
-		),
-		execsql(
 			"alter_customers_status",
 			`alter table customers modify status varchar(20);`,
 		),
@@ -106,6 +102,10 @@ var (
 		execsql(
 			"add_holder_name_to_accounts",
 			`alter table accounts add column holder_name varchar(60) default '';`,
+		),
+		execsql(
+			"create_account_ofac_searches",
+			`create table if not exists account_ofac_searches(account_ofac_search_id varchar(40) primary key, account_id varchar(40), entity_id varchar(40), sdn_name varchar(40), sdn_type integer, percentage_match double precision (5,2), created_at datetime);`,
 		),
 	)
 )

--- a/internal/database/sqlite.go
+++ b/internal/database/sqlite.go
@@ -76,10 +76,6 @@ var (
 			`create table if not exists accounts(account_id primary key, customer_id, user_id, encrypted_account_number, hashed_account_number, masked_account_number, routing_number, status, type, created_at datetime, deleted_at datetime);`,
 		),
 		execsql(
-			"create_account_ofac_searches",
-			`create table if not exists account_ofac_searches(account_ofac_search_id varchar(40) primary key, account_id varchar(40), entity_id varchar(40), sdn_name varchar(40), sdn_type integer, percentage_match double precision (5,2), created_at datetime);`,
-		),
-		execsql(
 			"add_customer_type",
 			`alter table customers add column type; update customers set type = 'individual' where type is null;`,
 		),
@@ -116,6 +112,10 @@ PRAGMA foreign_keys=on;`,
 		execsql(
 			"add_holder_name_to_accounts",
 			`alter table accounts add column holder_name default '';`,
+		),
+		execsql(
+			"create_account_ofac_searches",
+			`create table if not exists account_ofac_searches(account_ofac_search_id varchar(40) primary key, account_id varchar(40), entity_id varchar(40), sdn_name varchar(40), sdn_type integer, percentage_match double precision (5,2), created_at datetime);`,
 		),
 	)
 )

--- a/internal/database/sqlite.go
+++ b/internal/database/sqlite.go
@@ -76,6 +76,10 @@ var (
 			`create table if not exists accounts(account_id primary key, customer_id, user_id, encrypted_account_number, hashed_account_number, masked_account_number, routing_number, status, type, created_at datetime, deleted_at datetime);`,
 		),
 		execsql(
+			"create_account_ofac_searches",
+			`create table if not exists account_ofac_searches(account_ofac_search_id varchar(40) primary key, account_id varchar(40), entity_id varchar(40), sdn_name varchar(40), sdn_type integer, percentage_match double precision (5,2), created_at datetime);`,
+		),
+		execsql(
 			"add_customer_type",
 			`alter table customers add column type; update customers set type = 'individual' where type is null;`,
 		),

--- a/pkg/client/README.md
+++ b/pkg/client/README.md
@@ -49,6 +49,7 @@ Class | Method | HTTP request | Description
 *CustomersApi* | [**GetCustomerDisclaimers**](docs/CustomersApi.md#getcustomerdisclaimers) | **Get** /customers/{customerID}/disclaimers | Get customer disclaimers
 *CustomersApi* | [**GetCustomerDocumentContents**](docs/CustomersApi.md#getcustomerdocumentcontents) | **Get** /customers/{customerID}/documents/{documentID} | Get customer document
 *CustomersApi* | [**GetCustomerDocuments**](docs/CustomersApi.md#getcustomerdocuments) | **Get** /customers/{customerID}/documents | Get customer documents
+*CustomersApi* | [**GetLatestAccountOFACSearch**](docs/CustomersApi.md#getlatestaccountofacsearch) | **Get** /customers/{customerID}/accounts/{accountID}/ofac | Get latest OFAC search
 *CustomersApi* | [**GetLatestOFACSearch**](docs/CustomersApi.md#getlatestofacsearch) | **Get** /customers/{customerID}/ofac | Get latest OFAC search
 *CustomersApi* | [**Ping**](docs/CustomersApi.md#ping) | **Get** /ping | Ping Customers
 *CustomersApi* | [**RefreshOFACSearch**](docs/CustomersApi.md#refreshofacsearch) | **Put** /customers/{customerID}/refresh/ofac | Refresh customer OFAC search

--- a/pkg/client/api/openapi.yaml
+++ b/pkg/client/api/openapi.yaml
@@ -649,6 +649,65 @@ paths:
       summary: Validate Account
       tags:
       - Customers
+  /customers/{customerID}/accounts/{accountID}/ofac:
+    get:
+      description: Get the latest OFAC search for an account
+      operationId: getLatestAccountOFACSearch
+      parameters:
+      - description: Optional requestID allows application developer to trace requests
+          through the systems logs
+        example: rs4f9915
+        explode: false
+        in: header
+        name: X-Request-ID
+        required: false
+        schema:
+          type: string
+        style: simple
+      - description: Unique userID set by an auth proxy or client to identify and
+          isolate objects.
+        example: e3cdf999
+        explode: false
+        in: header
+        name: X-User-ID
+        required: false
+        schema:
+          type: string
+        style: simple
+      - description: customerID of the Customer
+        explode: false
+        in: path
+        name: customerID
+        required: true
+        schema:
+          example: e210a9d6
+          type: string
+        style: simple
+      - description: accountID of the Account to get latest OFAC search
+        explode: false
+        in: path
+        name: accountID
+        required: true
+        schema:
+          example: e210a9d6
+          type: string
+        style: simple
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OFACSearch'
+          description: OFAC search did not block account
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: An error occurred when refreshing OFAC data, see error(s)
+      summary: Get latest OFAC search
+      tags:
+      - Customers
   /customers/{customerID}/disclaimers:
     get:
       description: Get active disclaimers for the given customer

--- a/pkg/client/api_customers.go
+++ b/pkg/client/api_customers.go
@@ -1154,6 +1154,111 @@ func (a *CustomersApiService) GetCustomerDocuments(ctx _context.Context, custome
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
+// GetLatestAccountOFACSearchOpts Optional parameters for the method 'GetLatestAccountOFACSearch'
+type GetLatestAccountOFACSearchOpts struct {
+	XRequestID optional.String
+	XUserID    optional.String
+}
+
+/*
+GetLatestAccountOFACSearch Get latest OFAC search
+Get the latest OFAC search for an account
+ * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param customerID customerID of the Customer
+ * @param accountID accountID of the Account to get latest OFAC search
+ * @param optional nil or *GetLatestAccountOFACSearchOpts - Optional Parameters:
+ * @param "XRequestID" (optional.String) -  Optional requestID allows application developer to trace requests through the systems logs
+ * @param "XUserID" (optional.String) -  Unique userID set by an auth proxy or client to identify and isolate objects.
+@return OfacSearch
+*/
+func (a *CustomersApiService) GetLatestAccountOFACSearch(ctx _context.Context, customerID string, accountID string, localVarOptionals *GetLatestAccountOFACSearchOpts) (OfacSearch, *_nethttp.Response, error) {
+	var (
+		localVarHTTPMethod   = _nethttp.MethodGet
+		localVarPostBody     interface{}
+		localVarFormFileName string
+		localVarFileName     string
+		localVarFileBytes    []byte
+		localVarReturnValue  OfacSearch
+	)
+
+	// create path and map variables
+	localVarPath := a.client.cfg.BasePath + "/customers/{customerID}/accounts/{accountID}/ofac"
+	localVarPath = strings.Replace(localVarPath, "{"+"customerID"+"}", _neturl.QueryEscape(parameterToString(customerID, "")), -1)
+
+	localVarPath = strings.Replace(localVarPath, "{"+"accountID"+"}", _neturl.QueryEscape(parameterToString(accountID, "")), -1)
+
+	localVarHeaderParams := make(map[string]string)
+	localVarQueryParams := _neturl.Values{}
+	localVarFormParams := _neturl.Values{}
+
+	// to determine the Content-Type header
+	localVarHTTPContentTypes := []string{}
+
+	// set Content-Type header
+	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
+	if localVarHTTPContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHTTPContentType
+	}
+
+	// to determine the Accept header
+	localVarHTTPHeaderAccepts := []string{"application/json"}
+
+	// set Accept header
+	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
+	if localVarHTTPHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
+	}
+	if localVarOptionals != nil && localVarOptionals.XRequestID.IsSet() {
+		localVarHeaderParams["X-Request-ID"] = parameterToString(localVarOptionals.XRequestID.Value(), "")
+	}
+	if localVarOptionals != nil && localVarOptionals.XUserID.IsSet() {
+		localVarHeaderParams["X-User-ID"] = parameterToString(localVarOptionals.XUserID.Value(), "")
+	}
+	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+
+	localVarHTTPResponse, err := a.client.callAPI(r)
+	if err != nil || localVarHTTPResponse == nil {
+		return localVarReturnValue, localVarHTTPResponse, err
+	}
+
+	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarHTTPResponse.Body.Close()
+	if err != nil {
+		return localVarReturnValue, localVarHTTPResponse, err
+	}
+
+	if localVarHTTPResponse.StatusCode >= 300 {
+		newErr := GenericOpenAPIError{
+			body:  localVarBody,
+			error: localVarHTTPResponse.Status,
+		}
+		if localVarHTTPResponse.StatusCode == 400 {
+			var v Error
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			newErr.model = v
+		}
+		return localVarReturnValue, localVarHTTPResponse, newErr
+	}
+
+	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	if err != nil {
+		newErr := GenericOpenAPIError{
+			body:  localVarBody,
+			error: err.Error(),
+		}
+		return localVarReturnValue, localVarHTTPResponse, newErr
+	}
+
+	return localVarReturnValue, localVarHTTPResponse, nil
+}
+
 // GetLatestOFACSearchOpts Optional parameters for the method 'GetLatestOFACSearch'
 type GetLatestOFACSearchOpts struct {
 	XRequestID optional.String

--- a/pkg/client/docs/CustomersApi.md
+++ b/pkg/client/docs/CustomersApi.md
@@ -15,6 +15,7 @@ Method | HTTP request | Description
 [**GetCustomerDisclaimers**](CustomersApi.md#GetCustomerDisclaimers) | **Get** /customers/{customerID}/disclaimers | Get customer disclaimers
 [**GetCustomerDocumentContents**](CustomersApi.md#GetCustomerDocumentContents) | **Get** /customers/{customerID}/documents/{documentID} | Get customer document
 [**GetCustomerDocuments**](CustomersApi.md#GetCustomerDocuments) | **Get** /customers/{customerID}/documents | Get customer documents
+[**GetLatestAccountOFACSearch**](CustomersApi.md#GetLatestAccountOFACSearch) | **Get** /customers/{customerID}/accounts/{accountID}/ofac | Get latest OFAC search
 [**GetLatestOFACSearch**](CustomersApi.md#GetLatestOFACSearch) | **Get** /customers/{customerID}/ofac | Get latest OFAC search
 [**Ping**](CustomersApi.md#Ping) | **Get** /ping | Ping Customers
 [**RefreshOFACSearch**](CustomersApi.md#RefreshOFACSearch) | **Put** /customers/{customerID}/refresh/ofac | Refresh customer OFAC search
@@ -527,6 +528,54 @@ Name | Type | Description  | Notes
 ### Return type
 
 [**[]Document**](Document.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints)
+[[Back to Model list]](../README.md#documentation-for-models)
+[[Back to README]](../README.md)
+
+
+## GetLatestAccountOFACSearch
+
+> OfacSearch GetLatestAccountOFACSearch(ctx, customerID, accountID, optional)
+
+Get latest OFAC search
+
+Get the latest OFAC search for an account
+
+### Required Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
+**customerID** | **string**| customerID of the Customer | 
+**accountID** | **string**| accountID of the Account to get latest OFAC search | 
+ **optional** | ***GetLatestAccountOFACSearchOpts** | optional parameters | nil if no parameters
+
+### Optional Parameters
+
+Optional parameters are passed through a pointer to a GetLatestAccountOFACSearchOpts struct
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+
+
+ **xRequestID** | **optional.String**| Optional requestID allows application developer to trace requests through the systems logs | 
+ **xUserID** | **optional.String**| Unique userID set by an auth proxy or client to identify and isolate objects. | 
+
+### Return type
+
+[**OfacSearch**](OFACSearch.md)
 
 ### Authorization
 


### PR DESCRIPTION
This PR updates the account creation flow to perform an OFAC check using the Account `HolderName` and store the results into a new table `account_ofac_searches`.