### PR TITLE
search: always return an allocated array for JSON marshal

### DIFF
--- a/cmd/server/customer_search.go
+++ b/cmd/server/customer_search.go
@@ -76,24 +76,27 @@ func (r *sqlCustomerRepository) searchCustomers(params searchParams) ([]*client.
 	defer stmt.Close()
 
 	var customerIDs []string
+	customers := make([]*client.Customer, 0)
+
+	// grab customerIDs
 	rows, err := stmt.Query(args...)
 	if err != nil {
-		return nil, err
+		return customers, err
 	}
 	for rows.Next() {
 		var customerID string
 		if err := rows.Scan(&customerID); err == nil {
 			customerIDs = append(customerIDs, customerID)
 		} else {
-			return nil, err
+			return customers, err
 		}
 	}
 
-	customers := make([]*client.Customer, 0)
+	// Read each Customer
 	for i := range customerIDs {
 		cust, err := r.getCustomer(customerIDs[i])
 		if err != nil {
-			return nil, fmt.Errorf("search: customerID=%s error=%v", customerIDs[i], err)
+			return customers, fmt.Errorf("search: customerID=%s error=%v", customerIDs[i], err)
 		}
 		customers = append(customers, cust)
 	}

--- a/cmd/server/customer_search_test.go
+++ b/cmd/server/customer_search_test.go
@@ -143,6 +143,14 @@ func TestCustomerSearch__query(t *testing.T) {
 	}
 }
 
+func TestCustomerSearchEmpty(t *testing.T) {
+	scope := Setup(t)
+	customers, _ := scope.GetCustomers("")
+	if customers == nil {
+		t.Fatalf("expected allocated array:\n  %T %#v", customers, customers)
+	}
+}
+
 func TestGet20MostRecentlyCreatedCustomersByDefault(t *testing.T) {
 	scope := Setup(t)
 	scope.CreateCustomers(100, client.INDIVIDUAL)


### PR DESCRIPTION
In Go JSON marshaling will render 'null' for an unallocated array and '[]' for an allocated array. This is unexpected by some JS apps that will fail to treat null like an empty array.

As a result of our X-Namespace change the first query in searchCustomers can return zero results which will return the unallocated array to the UI.