### PR TITLE
fix flakey test

### DIFF
--- a/cmd/server/customer_search_test.go
+++ b/cmd/server/customer_search_test.go
@@ -182,30 +182,24 @@ func TestGet100MostRecentlyCreatedCustomersWhenSpecifyingMoreThanAvailable(t *te
 func TestGetCustomersWithVerifiedStatus(t *testing.T) {
 	// Create two customers. 1 with Unknown STATUS and 1 with Verified
 	scope := Setup(t)
-	scope.CreateCustomers(2, client.INDIVIDUAL)
-	customers, _ := scope.GetCustomers("?count=120")
-	scope.assert.Equal(2, len(customers))
-	for i := 0; i < len(customers); i++ {
-		if i%2 == 0 {
-			// update status
-			if err := scope.customerRepo.updateCustomerStatus(customers[i].CustomerID, client.VERIFIED, "test comment"); err != nil {
-				print(err)
-			}
-		}
+	customer := scope.CreateCustomer("John", "Doe", "john.doe@email.com", client.INDIVIDUAL)
+	if err := scope.customerRepo.updateCustomerStatus(customer.CustomerID, client.VERIFIED, "test comment"); err != nil {
+		print(err)
 	}
+	scope.CreateCustomer("Jane", "Doe", "jane.doe@email.com", client.INDIVIDUAL)
 
 	// Should have 1 Verified Status
-	customers, _ = scope.GetCustomers("?status=Verified&count=20")
-	scope.assert.Equal(1, len(customers))
-	for i := 0; i < len(customers); i++ {
-		scope.assert.Equal("Verified", string(customers[i].Status))
+	verifiedCustomers, _ := scope.GetCustomers("?status=Verified&count=20")
+	scope.assert.Equal(1, len(verifiedCustomers))
+	for i := 0; i < len(verifiedCustomers); i++ {
+		scope.assert.Equal("Verified", string(verifiedCustomers[i].Status))
 	}
 
 	// Should have 1 Unknown Status
-	customers, _ = scope.GetCustomers("?status=Unknown&count=20")
-	scope.assert.Equal(1, len(customers))
-	for i := 0; i < len(customers); i++ {
-		scope.assert.Equal("Unknown", string(customers[i].Status))
+	unknownStatusCustomers, _ := scope.GetCustomers("?status=Unknown&count=20")
+	scope.assert.Equal(1, len(unknownStatusCustomers))
+	for i := 0; i < len(unknownStatusCustomers); i++ {
+		scope.assert.Equal("Unknown", string(unknownStatusCustomers[i].Status))
 	}
 }
 


### PR DESCRIPTION
This PR refactors a test 'TestGetCustomersWithVerifiedStatus' that was failing intermittently. I changed this test to more deterministically create customers and reliably change the status on one customer.

To ensure the test no longer fails intermittently, I ran `go test ./cmd/server/ -count 100 -run TestGetCustomersWithVerifiedStatus -v ` and the test no longer fails.