### PR TITLE
set logger for database migrator (instead of default stdout)

### DIFF
--- a/internal/database/mysql.go
+++ b/internal/database/mysql.go
@@ -161,8 +161,12 @@ func (my *mysql) Connect() (*sql.DB, error) {
 		return nil, err
 	}
 
+	migratorLogger := migrator.WithLogger(migrator.LoggerFunc(func(msg string, args ...interface{}) {
+		my.logger.Log("mysql", msg)
+	}))
+
 	// Migrate our database
-	if m, err := migrator.New(mysqlMigrations); err != nil {
+	if m, err := migrator.New(migratorLogger, mysqlMigrations); err != nil {
 		return nil, err
 	} else {
 		if err := m.Migrate(db); err != nil {

--- a/internal/database/sqlite.go
+++ b/internal/database/sqlite.go
@@ -177,8 +177,12 @@ func (s *sqlite) Connect() (*sql.DB, error) {
 		return db, err
 	}
 
+	migratorLogger := migrator.WithLogger(migrator.LoggerFunc(func(msg string, args ...interface{}) {
+		s.logger.Log("sqlite", msg)
+	}))
+
 	// Migrate our database
-	if m, err := migrator.New(sqliteMigrations); err != nil {
+	if m, err := migrator.New(migratorLogger, sqliteMigrations); err != nil {
 		return db, err
 	} else {
 		if err := m.Migrate(db); err != nil {


### PR DESCRIPTION
Send migrator output to log instead of stdout