### PR TITLE
Upload/Download organization logo

### DIFF
--- a/api/client.yaml
+++ b/api/client.yaml
@@ -86,6 +86,47 @@ paths:
             application/json:
               schema:
                 $ref: 'https://raw.githubusercontent.com/moov-io/api/master/openapi-common.yaml#/components/schemas/Error'
+  /configuration/logo:
+    put:
+      tags: [Configuration]
+      summary: Upload organization logo
+      description: Upload an organization's logo, or update it if it already exists
+      operationId: uploadOrganizationLogo
+      parameters:
+        - name: X-Organization
+          in: header
+          description: Value used to separate and identify models
+          example: org342
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              properties:
+                file:
+                  description: Logo image file to be uploaded
+                  type: string
+                  format: binary
+              required:
+                - file
+            encoding:
+              file:
+                contentType: image/jpeg, image/svg+xml, image/gif, image/png
+      responses:
+        '204':
+          description: Logo image file was successfully uploaded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrganizationConfiguration'
+        '400':
+          description: Configuration was not updated, see error(s)
+          content:
+            application/json:
+              schema:
+                $ref: 'https://raw.githubusercontent.com/moov-io/api/master/openapi-common.yaml#/components/schemas/Error'
   /customers:
     get:
       tags: [Customers]

--- a/api/client.yaml
+++ b/api/client.yaml
@@ -87,6 +87,45 @@ paths:
               schema:
                 $ref: 'https://raw.githubusercontent.com/moov-io/api/master/openapi-common.yaml#/components/schemas/Error'
   /configuration/logo:
+    get:
+      tags: [Configuration]
+      summary: Get organization logo
+      description: Retrieve the organization's logo
+      operationId: getOrganizationLogo
+      parameters:
+        - name: X-Organization
+          in: header
+          description: Value used to separate and identify models
+          example: org342
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Logo image file in original upload format
+          content:
+            image/png:
+              schema:
+                type: string
+                format: binary
+            image/jpg:
+              schema:
+                type: string
+                format: binary
+            image/svg+xml:
+              schema:
+                type: string
+                format: binary
+            image/gif:
+              schema:
+                type: string
+                format: binary
+        '400':
+          description: Failed to retrieve image file, see error(s)
+          content:
+            application/json:
+              schema:
+                $ref: 'https://raw.githubusercontent.com/moov-io/api/master/openapi-common.yaml#/components/schemas/Error'
     put:
       tags: [Configuration]
       summary: Upload organization logo

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -165,7 +165,7 @@ func main() {
 		Repo: accountsRepo, WatchmanClient: watchmanClient,
 	}
 
-	bucket := storage.GetBucket(logger, os.Getenv("DOCUMENTS_BUCKET"), util.Or(os.Getenv("DOCUMENTS_PROVIDER"), "file"), signer)
+	bucket := storage.GetBucket(logger, util.Or(os.Getenv("DOCUMENTS_BUCKET"), "./storage"), util.Or(os.Getenv("DOCUMENTS_PROVIDER"), "file"), signer)
 
 	// Setup business HTTP routes
 	router := mux.NewRouter()
@@ -180,7 +180,7 @@ func main() {
 
 	// Add Configuration routes
 	configRepo := configuration.NewRepository(db)
-	configuration.RegisterRoutes(logger, router, configRepo)
+	configuration.RegisterRoutes(logger, router, configRepo, bucket)
 
 	// Optionally serve /files/ as our fileblob routes
 	// Note: FILEBLOB_BASE_URL needs to match something that's routed to /files/...

--- a/pkg/client/README.md
+++ b/pkg/client/README.md
@@ -39,7 +39,9 @@ All URIs are relative to *http://localhost:8087*
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------
 *ConfigurationApi* | [**GetConfiguration**](docs/ConfigurationApi.md#getconfiguration) | **Get** /configuration/customers | Get Configuration
+*ConfigurationApi* | [**GetOrganizationLogo**](docs/ConfigurationApi.md#getorganizationlogo) | **Get** /configuration/logo | Get organization logo
 *ConfigurationApi* | [**UpdateConfiguration**](docs/ConfigurationApi.md#updateconfiguration) | **Put** /configuration/customers | Update Configuration
+*ConfigurationApi* | [**UploadOrganizationLogo**](docs/ConfigurationApi.md#uploadorganizationlogo) | **Put** /configuration/logo | Upload organization logo
 *CustomersApi* | [**AcceptDisclaimer**](docs/CustomersApi.md#acceptdisclaimer) | **Post** /customers/{customerID}/disclaimers/{disclaimerID} | Accept customer disclaimer
 *CustomersApi* | [**AddCustomerAddress**](docs/CustomersApi.md#addcustomeraddress) | **Post** /customers/{customerID}/address | Add customer address
 *CustomersApi* | [**CompleteAccountValidation**](docs/CustomersApi.md#completeaccountvalidation) | **Put** /customers/{customerID}/accounts/{accountID}/validations | Complete Account Validation

--- a/pkg/client/api/openapi.yaml
+++ b/pkg/client/api/openapi.yaml
@@ -92,6 +92,93 @@ paths:
       summary: Update Configuration
       tags:
       - Configuration
+  /configuration/logo:
+    get:
+      description: Retrieve the organization's logo
+      operationId: getOrganizationLogo
+      parameters:
+      - description: Value used to separate and identify models
+        example: org342
+        explode: false
+        in: header
+        name: X-Organization
+        required: true
+        schema:
+          type: string
+        style: simple
+      responses:
+        "200":
+          content:
+            image/png:
+              schema:
+                format: binary
+                type: string
+            image/jpg:
+              schema:
+                format: binary
+                type: string
+            image/svg+xml:
+              schema:
+                format: binary
+                type: string
+            image/gif:
+              schema:
+                format: binary
+                type: string
+          description: Logo image file in original upload format
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Failed to retrieve image file, see error(s)
+      summary: Get organization logo
+      tags:
+      - Configuration
+    put:
+      description: Upload an organization's logo, or update it if it already exists
+      operationId: uploadOrganizationLogo
+      parameters:
+      - description: Value used to separate and identify models
+        example: org342
+        explode: false
+        in: header
+        name: X-Organization
+        required: true
+        schema:
+          type: string
+        style: simple
+      requestBody:
+        content:
+          multipart/form-data:
+            encoding:
+              file:
+                contentType: image/jpeg, image/svg+xml, image/gif, image/png
+                style: form
+            schema:
+              properties:
+                file:
+                  description: Logo image file to be uploaded
+                  format: binary
+                  type: string
+              required:
+              - file
+      responses:
+        "204":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrganizationConfiguration'
+          description: Logo image file was successfully uploaded
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Configuration was not updated, see error(s)
+      summary: Upload organization logo
+      tags:
+      - Configuration
   /customers:
     get:
       description: Search for customers using different filter parameters

--- a/pkg/client/api_configuration.go
+++ b/pkg/client/api_configuration.go
@@ -11,11 +11,11 @@ package client
 
 import (
 	_context "context"
+	"github.com/antihax/optional"
 	_ioutil "io/ioutil"
 	_nethttp "net/http"
 	_neturl "net/url"
-
-	"github.com/antihax/optional"
+	"os"
 )
 
 // Linger please
@@ -111,6 +111,92 @@ func (a *ConfigurationApiService) GetConfiguration(ctx _context.Context, localVa
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
+/*
+GetOrganizationLogo Get organization logo
+Retrieve the organization&#39;s logo
+ * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param xOrganization Value used to separate and identify models
+@return *os.File
+*/
+func (a *ConfigurationApiService) GetOrganizationLogo(ctx _context.Context, xOrganization string) (*os.File, *_nethttp.Response, error) {
+	var (
+		localVarHTTPMethod   = _nethttp.MethodGet
+		localVarPostBody     interface{}
+		localVarFormFileName string
+		localVarFileName     string
+		localVarFileBytes    []byte
+		localVarReturnValue  *os.File
+	)
+
+	// create path and map variables
+	localVarPath := a.client.cfg.BasePath + "/configuration/logo"
+	localVarHeaderParams := make(map[string]string)
+	localVarQueryParams := _neturl.Values{}
+	localVarFormParams := _neturl.Values{}
+
+	// to determine the Content-Type header
+	localVarHTTPContentTypes := []string{}
+
+	// set Content-Type header
+	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
+	if localVarHTTPContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHTTPContentType
+	}
+
+	// to determine the Accept header
+	localVarHTTPHeaderAccepts := []string{"image/png", "image/jpg", "image/svg+xml", "image/gif", "application/json"}
+
+	// set Accept header
+	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
+	if localVarHTTPHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
+	}
+	localVarHeaderParams["X-Organization"] = parameterToString(xOrganization, "")
+	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+
+	localVarHTTPResponse, err := a.client.callAPI(r)
+	if err != nil || localVarHTTPResponse == nil {
+		return localVarReturnValue, localVarHTTPResponse, err
+	}
+
+	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarHTTPResponse.Body.Close()
+	if err != nil {
+		return localVarReturnValue, localVarHTTPResponse, err
+	}
+
+	if localVarHTTPResponse.StatusCode >= 300 {
+		newErr := GenericOpenAPIError{
+			body:  localVarBody,
+			error: localVarHTTPResponse.Status,
+		}
+		if localVarHTTPResponse.StatusCode == 400 {
+			var v Error
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			newErr.model = v
+		}
+		return localVarReturnValue, localVarHTTPResponse, newErr
+	}
+
+	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	if err != nil {
+		newErr := GenericOpenAPIError{
+			body:  localVarBody,
+			error: err.Error(),
+		}
+		return localVarReturnValue, localVarHTTPResponse, newErr
+	}
+
+	return localVarReturnValue, localVarHTTPResponse, nil
+}
+
 // UpdateConfigurationOpts Optional parameters for the method 'UpdateConfiguration'
 type UpdateConfigurationOpts struct {
 	XOrganization optional.String
@@ -163,6 +249,101 @@ func (a *ConfigurationApiService) UpdateConfiguration(ctx _context.Context, orga
 	}
 	// body params
 	localVarPostBody = &organizationConfiguration
+	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+
+	localVarHTTPResponse, err := a.client.callAPI(r)
+	if err != nil || localVarHTTPResponse == nil {
+		return localVarReturnValue, localVarHTTPResponse, err
+	}
+
+	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarHTTPResponse.Body.Close()
+	if err != nil {
+		return localVarReturnValue, localVarHTTPResponse, err
+	}
+
+	if localVarHTTPResponse.StatusCode >= 300 {
+		newErr := GenericOpenAPIError{
+			body:  localVarBody,
+			error: localVarHTTPResponse.Status,
+		}
+		if localVarHTTPResponse.StatusCode == 400 {
+			var v Error
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			newErr.model = v
+		}
+		return localVarReturnValue, localVarHTTPResponse, newErr
+	}
+
+	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	if err != nil {
+		newErr := GenericOpenAPIError{
+			body:  localVarBody,
+			error: err.Error(),
+		}
+		return localVarReturnValue, localVarHTTPResponse, newErr
+	}
+
+	return localVarReturnValue, localVarHTTPResponse, nil
+}
+
+/*
+UploadOrganizationLogo Upload organization logo
+Upload an organization&#39;s logo, or update it if it already exists
+ * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param xOrganization Value used to separate and identify models
+ * @param file Logo image file to be uploaded
+@return OrganizationConfiguration
+*/
+func (a *ConfigurationApiService) UploadOrganizationLogo(ctx _context.Context, xOrganization string, file *os.File) (OrganizationConfiguration, *_nethttp.Response, error) {
+	var (
+		localVarHTTPMethod   = _nethttp.MethodPut
+		localVarPostBody     interface{}
+		localVarFormFileName string
+		localVarFileName     string
+		localVarFileBytes    []byte
+		localVarReturnValue  OrganizationConfiguration
+	)
+
+	// create path and map variables
+	localVarPath := a.client.cfg.BasePath + "/configuration/logo"
+	localVarHeaderParams := make(map[string]string)
+	localVarQueryParams := _neturl.Values{}
+	localVarFormParams := _neturl.Values{}
+
+	// to determine the Content-Type header
+	localVarHTTPContentTypes := []string{"multipart/form-data"}
+
+	// set Content-Type header
+	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
+	if localVarHTTPContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHTTPContentType
+	}
+
+	// to determine the Accept header
+	localVarHTTPHeaderAccepts := []string{"application/json"}
+
+	// set Accept header
+	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
+	if localVarHTTPHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
+	}
+	localVarHeaderParams["X-Organization"] = parameterToString(xOrganization, "")
+	localVarFormFileName = "file"
+	localVarFile := file
+	if localVarFile != nil {
+		fbs, _ := _ioutil.ReadAll(localVarFile)
+		localVarFileBytes = fbs
+		localVarFileName = localVarFile.Name()
+		localVarFile.Close()
+	}
 	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err

--- a/pkg/client/docs/ConfigurationApi.md
+++ b/pkg/client/docs/ConfigurationApi.md
@@ -5,7 +5,9 @@ All URIs are relative to *http://localhost:8087*
 Method | HTTP request | Description
 ------------- | ------------- | -------------
 [**GetConfiguration**](ConfigurationApi.md#GetConfiguration) | **Get** /configuration/customers | Get Configuration
+[**GetOrganizationLogo**](ConfigurationApi.md#GetOrganizationLogo) | **Get** /configuration/logo | Get organization logo
 [**UpdateConfiguration**](ConfigurationApi.md#UpdateConfiguration) | **Put** /configuration/customers | Update Configuration
+[**UploadOrganizationLogo**](ConfigurationApi.md#UploadOrganizationLogo) | **Put** /configuration/logo | Upload organization logo
 
 
 
@@ -52,6 +54,40 @@ No authorization required
 [[Back to README]](../README.md)
 
 
+## GetOrganizationLogo
+
+> *os.File GetOrganizationLogo(ctx, xOrganization)
+
+Get organization logo
+
+Retrieve the organization's logo
+
+### Required Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
+**xOrganization** | **string**| Value used to separate and identify models | 
+
+### Return type
+
+[***os.File**](*os.File.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: image/png, image/jpg, image/svg+xml, image/gif, application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints)
+[[Back to Model list]](../README.md#documentation-for-models)
+[[Back to README]](../README.md)
+
+
 ## UpdateConfiguration
 
 > OrganizationConfiguration UpdateConfiguration(ctx, organizationConfiguration, optional)
@@ -90,6 +126,41 @@ No authorization required
 ### HTTP request headers
 
 - **Content-Type**: application/json
+- **Accept**: application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints)
+[[Back to Model list]](../README.md#documentation-for-models)
+[[Back to README]](../README.md)
+
+
+## UploadOrganizationLogo
+
+> OrganizationConfiguration UploadOrganizationLogo(ctx, xOrganization, file)
+
+Upload organization logo
+
+Upload an organization's logo, or update it if it already exists
+
+### Required Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
+**xOrganization** | **string**| Value used to separate and identify models | 
+**file** | ***os.File*****os.File**| Logo image file to be uploaded | 
+
+### Return type
+
+[**OrganizationConfiguration**](OrganizationConfiguration.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: multipart/form-data
 - **Accept**: application/json
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints)

--- a/pkg/configuration/router.go
+++ b/pkg/configuration/router.go
@@ -5,20 +5,55 @@
 package configuration
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
 	"net/http"
+	"path"
+	"strings"
+	"time"
 
 	moovhttp "github.com/moov-io/base/http"
 	"github.com/moov-io/customers/pkg/client"
+	"github.com/moov-io/customers/pkg/documents/storage"
 	"github.com/moov-io/customers/pkg/route"
+	"gocloud.dev/blob"
 
 	"github.com/go-kit/kit/log"
 	"github.com/gorilla/mux"
 )
 
-func RegisterRoutes(logger log.Logger, r *mux.Router, repo Repository) {
+const maxImageSize int64 = 20 * 1024 * 1024 // 20MB
+
+var (
+	allowedContentTypes = map[string]bool{
+		"image/jpeg":    true,
+		"image/svg+xml": true,
+		"image/gif":     true,
+		"image/png":     true,
+	}
+
+	errMissingFile     = errors.New("expected multipart upload with key of 'file'")
+	errUnsupportedType = fmt.Errorf("file type must be one of %s", listAllowedContentTypes())
+)
+
+func listAllowedContentTypes() string {
+	types := make([]string, len(allowedContentTypes))
+	idx := 0
+	for t := range allowedContentTypes {
+		types[idx] = t
+		idx++
+	}
+	return strings.Join(types, ",")
+}
+
+func RegisterRoutes(logger log.Logger, r *mux.Router, repo Repository, bucketFunc storage.BucketFunc) {
 	r.Methods("GET").Path("/configuration/customers").HandlerFunc(getOrganizationConfig(logger, repo))
 	r.Methods("PUT").Path("/configuration/customers").HandlerFunc(updateOrganizationConfig(logger, repo))
+	r.Methods("PUT").Path("/configuration/logo").HandlerFunc(uploadOrganizationLogo(logger, repo, bucketFunc))
 }
 
 func getOrganizationConfig(logger log.Logger, repo Repository) http.HandlerFunc {
@@ -61,4 +96,73 @@ func updateOrganizationConfig(logger log.Logger, repo Repository) http.HandlerFu
 		w.WriteHeader(http.StatusOK)
 		json.NewEncoder(w).Encode(cfg)
 	}
+}
+
+func uploadOrganizationLogo(logger log.Logger, repo Repository, bucketFactory storage.BucketFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		requestID := moovhttp.GetRequestID(r)
+		organization := route.GetOrganization(w, r)
+		if organization == "" {
+			logger.Log("configuration", "upload logo called with no organization header", "requestID", requestID)
+			return
+		}
+
+		file, _, err := r.FormFile("file")
+		if file == nil || err != nil {
+			logger.Log("configuration", errMissingFile, "error", err, "organization", organization, "requestID", requestID)
+			moovhttp.Problem(w, errMissingFile)
+			return
+		}
+		defer file.Close()
+
+		// Detect the content type by reading the first 512 bytes of r.Body (read into file as we expect a multipart request)
+		buf := make([]byte, 512)
+		if _, err := file.Read(buf); err != nil && err != io.EOF {
+			logger.Log("configuration", "problem reading file", "error", err, "organization", organization, "requestID", requestID)
+			moovhttp.Problem(w, err)
+			return
+		}
+
+		contentType := http.DetectContentType(buf)
+		if !allowedContentTypes[contentType] {
+			logger.Log("configuration", "unsupported content type for logo image file", "error", err, "contentType", contentType, "organization", organization, "requestID", requestID)
+			moovhttp.Problem(w, errUnsupportedType)
+			return
+		}
+
+		bucket, err := bucketFactory()
+		if err != nil {
+			logger.Log("configuration", "problem uploading logo image", "error", err, "organization", organization, "requestID", requestID)
+			moovhttp.Problem(w, err)
+			return
+		}
+		defer bucket.Close()
+
+		ctx, cancelFn := context.WithTimeout(r.Context(), 60*time.Second)
+		defer cancelFn()
+
+		writer, err := bucket.NewWriter(ctx, makeDocumentKey(organization), &blob.WriterOptions{
+			ContentDisposition: "inline",
+			ContentType:        contentType,
+		})
+		if err != nil {
+			logger.Log("configuration", "problem uploading logo image", "error", err, "organization", organization, "requestID", requestID)
+			moovhttp.Problem(w, err)
+			return
+		}
+		defer writer.Close()
+
+		written, err := io.Copy(writer, io.LimitReader(io.MultiReader(bytes.NewReader(buf), file), maxImageSize))
+		if err != nil || written == 0 {
+			logger.Log("configuration", "problem uploading logo image", "error", err, "organization", organization, "requestID", requestID)
+			moovhttp.Problem(w, fmt.Errorf("problem writing file - wrote %d bytes with error=%v", written, err))
+			return
+		}
+
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+func makeDocumentKey(organization string) string {
+	return path.Join("configuration", organization, "logo")
 }

--- a/pkg/configuration/router.go
+++ b/pkg/configuration/router.go
@@ -209,5 +209,5 @@ func uploadOrganizationLogo(logger log.Logger, repo Repository, bucketFactory st
 }
 
 func makeDocumentKey(organization string) string {
-	return path.Join("configuration", organization, "logo")
+	return path.Join("organizations", organization, "logo")
 }

--- a/pkg/configuration/router_test.go
+++ b/pkg/configuration/router_test.go
@@ -8,12 +8,17 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"io"
+	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/moov-io/base"
 	"github.com/moov-io/customers/pkg/client"
+	"github.com/moov-io/customers/pkg/documents/storage"
 
 	"github.com/go-kit/kit/log"
 	"github.com/gorilla/mux"
@@ -33,7 +38,7 @@ func TestRouterGet(t *testing.T) {
 	w := httptest.NewRecorder()
 
 	router := mux.NewRouter()
-	RegisterRoutes(log.NewNopLogger(), router, repo)
+	RegisterRoutes(log.NewNopLogger(), router, repo, storage.NewTestBucket(t))
 	router.ServeHTTP(w, req)
 	w.Flush()
 
@@ -61,7 +66,7 @@ func TestRouterGetErr(t *testing.T) {
 	w := httptest.NewRecorder()
 
 	router := mux.NewRouter()
-	RegisterRoutes(log.NewNopLogger(), router, repo)
+	RegisterRoutes(log.NewNopLogger(), router, repo, storage.NewTestBucket(t))
 	router.ServeHTTP(w, req)
 	w.Flush()
 
@@ -80,7 +85,7 @@ func TestRouterGetMissing(t *testing.T) {
 	w := httptest.NewRecorder()
 
 	router := mux.NewRouter()
-	RegisterRoutes(log.NewNopLogger(), router, repo)
+	RegisterRoutes(log.NewNopLogger(), router, repo, storage.NewTestBucket(t))
 	router.ServeHTTP(w, req)
 	w.Flush()
 
@@ -106,7 +111,7 @@ func TestRouterUpdate(t *testing.T) {
 	w := httptest.NewRecorder()
 
 	router := mux.NewRouter()
-	RegisterRoutes(log.NewNopLogger(), router, repo)
+	RegisterRoutes(log.NewNopLogger(), router, repo, storage.NewTestBucket(t))
 	router.ServeHTTP(w, req)
 	w.Flush()
 
@@ -140,7 +145,7 @@ func TestRouterUpdateErr(t *testing.T) {
 	w := httptest.NewRecorder()
 
 	router := mux.NewRouter()
-	RegisterRoutes(log.NewNopLogger(), router, repo)
+	RegisterRoutes(log.NewNopLogger(), router, repo, storage.NewTestBucket(t))
 	router.ServeHTTP(w, req)
 	w.Flush()
 
@@ -165,9 +170,107 @@ func TestRouterUpdateMissing(t *testing.T) {
 	w := httptest.NewRecorder()
 
 	router := mux.NewRouter()
-	RegisterRoutes(log.NewNopLogger(), router, repo)
+	RegisterRoutes(log.NewNopLogger(), router, repo, storage.NewTestBucket(t))
 	router.ServeHTTP(w, req)
 	w.Flush()
 
 	require.Equal(t, w.Code, http.StatusBadRequest)
+}
+
+func TestRouterUploadLogo(t *testing.T) {
+	w := httptest.NewRecorder()
+	req := multipartRequest(t, "file", "image.png")
+	req.Header.Set("x-request-id", "test")
+	req.Header.Set("X-organization", "moov")
+
+	router := mux.NewRouter()
+	RegisterRoutes(log.NewNopLogger(), router, &mockRepository{}, storage.NewTestBucket(t))
+	router.ServeHTTP(w, req)
+	w.Flush()
+
+	require.Equal(t, http.StatusNoContent, w.Result().StatusCode)
+}
+
+func TestRouterUploadLogo_missingHeader(t *testing.T) {
+	w := httptest.NewRecorder()
+	router := mux.NewRouter()
+	RegisterRoutes(log.NewNopLogger(), router, &mockRepository{}, nil)
+	router.ServeHTTP(w, httptest.NewRequest(http.MethodPut, "/configuration/logo", nil))
+	w.Flush()
+
+	require.Equal(t, w.Code, http.StatusBadRequest)
+	response := make(map[string]string)
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatal(err)
+	}
+	require.Contains(t, response, "error")
+	require.Equal(t, response["error"], "missing X-Organization header")
+}
+
+func TestRouterUploadLogo_missingFile(t *testing.T) {
+	w := httptest.NewRecorder()
+	req := multipartRequest(t, "foo", "image.png")
+	req.Header.Set("x-request-id", "test")
+	req.Header.Set("X-organization", "moov")
+
+	router := mux.NewRouter()
+	RegisterRoutes(log.NewNopLogger(), router, &mockRepository{}, storage.NewTestBucket(t))
+	router.ServeHTTP(w, req)
+	w.Flush()
+
+	require.Equal(t, w.Code, http.StatusBadRequest)
+	response := make(map[string]string)
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatal(err)
+	}
+	require.Contains(t, response, "error")
+	require.Equal(t, response["error"], errMissingFile.Error())
+}
+
+func TestRouterUploadLogo_unsupportedFileType(t *testing.T) {
+	w := httptest.NewRecorder()
+	req := multipartRequest(t, "file", "bogus.txt")
+	req.Header.Set("x-request-id", "test")
+	req.Header.Set("X-organization", "moov")
+
+	router := mux.NewRouter()
+	RegisterRoutes(log.NewNopLogger(), router, &mockRepository{}, storage.NewTestBucket(t))
+	router.ServeHTTP(w, req)
+	w.Flush()
+
+	require.Equal(t, w.Code, http.StatusBadRequest)
+	response := make(map[string]string)
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatal(err)
+	}
+	require.Contains(t, response, "error")
+	require.Equal(t, response["error"], errUnsupportedType.Error())
+}
+
+func multipartRequest(t *testing.T, fieldName string, fileName string) *http.Request {
+	fd, err := os.Open(filepath.Join("testdata", fileName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer fd.Close()
+
+	var body bytes.Buffer
+	w := multipart.NewWriter(&body)
+	part, err := w.CreateFormFile(fieldName, fd.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = io.Copy(part, fd); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	req, err := http.NewRequest("PUT", "/configuration/logo", &body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", w.FormDataContentType())
+	return req
 }

--- a/pkg/configuration/testdata/bogus.txt
+++ b/pkg/configuration/testdata/bogus.txt
@@ -1,0 +1,1 @@
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce efficitur dui a sodales varius.


### PR DESCRIPTION
Enables customers to upload and retrieve their organization's logo as an image file.

Changes:
- new endpoint `PUT` `/configuration/logo`
  - multipart form request
  - requires `X-Organization` header
  - each request replaces any pre-existing logo file
  - document key `configuration/{orgID}/logo`
- new endpoint `GET` `/configuration/logo`
  - requires `X-Organization` header
  - returns the raw file along with the appropriate `Content-Type` header
- updates OpenAPI specification to include new endpoints
- generate updated client

This PR also updates the TestBucket concept to remove the underlying directory using `testing`'s `Cleanup()` method.