### PR TITLE
validation: ensure that a primary address is not created if one already exists for the customer

### DIFF
--- a/pkg/customers/address_test.go
+++ b/pkg/customers/address_test.go
@@ -27,7 +27,7 @@ func TestCustomers__addCustomerAddress(t *testing.T) {
 	err := repo.CreateCustomer(cust, "organization")
 	require.NoError(t, err)
 
-	address := address{
+	addrPayload := address{
 		Address1:   "123 1st st",
 		City:       "Denver",
 		State:      "CO",
@@ -35,7 +35,7 @@ func TestCustomers__addCustomerAddress(t *testing.T) {
 		Country:    "USA",
 		Type:       "primary",
 	}
-	payload, err := json.Marshal(address)
+	payload, err := json.Marshal(addrPayload)
 	require.NoError(t, err)
 
 	w := httptest.NewRecorder()
@@ -53,16 +53,29 @@ func TestCustomers__addCustomerAddress(t *testing.T) {
 	got := customerResp.Addresses[0]
 	want := client.CustomerAddress{
 		AddressID:  got.AddressID,
-		Type:       address.Type,
-		Address1:   address.Address1,
-		Address2:   address.Address2,
-		City:       address.City,
-		State:      address.State,
-		PostalCode: address.PostalCode,
-		Country:    address.Country,
+		Type:       addrPayload.Type,
+		Address1:   addrPayload.Address1,
+		Address2:   addrPayload.Address2,
+		City:       addrPayload.City,
+		State:      addrPayload.State,
+		PostalCode: addrPayload.PostalCode,
+		Country:    addrPayload.Country,
 	}
 
 	require.Equal(t, want, got)
+
+	/* Error on duplicate type primary */
+	w = httptest.NewRecorder()
+	payload, err = json.Marshal(addrPayload)
+	require.NoError(t, err)
+	req = httptest.NewRequest("POST", fmt.Sprintf("/customers/%s/addresses", cust.CustomerID), bytes.NewReader(payload))
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	var errResp struct {
+		ErrorMsg string `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &errResp))
+	require.Contains(t, errResp.ErrorMsg, ErrAddressTypeDuplicate.Error())
 }
 
 func TestCustomers__updateCustomerAddress(t *testing.T) {
@@ -77,36 +90,59 @@ func TestCustomers__updateCustomerAddress(t *testing.T) {
 	err := repo.CreateCustomer(cust, "organization")
 	require.NoError(t, err)
 
-	address := address{
-		Address1:   "123 1st st",
-		City:       "Denver",
-		State:      "CO",
-		PostalCode: "12345",
-		Country:    "USA",
-		Type:       "primary",
+	addrRequests := []address{
+		{
+			Address1:   "111 1st st",
+			City:       "Denver",
+			State:      "CO",
+			PostalCode: "12345",
+			Country:    "USA",
+			Type:       "primary",
+		},
+		{
+			Address1:   "222 2nd st",
+			City:       "Denver",
+			State:      "CO",
+			PostalCode: "12345",
+			Country:    "USA",
+			Type:       "secondary",
+		},
 	}
-	require.NoError(t, repo.addCustomerAddress(cust.CustomerID, address))
-	cust, err = repo.GetCustomer(cust.CustomerID) // refresh customer object after updating address
-	require.NoError(t, err)
+	for _, req := range addrRequests {
+		require.NoError(t, repo.addCustomerAddress(cust.CustomerID, req))
+		cust, err = repo.GetCustomer(cust.CustomerID) // refresh customer object after updating address
+		require.NoError(t, err)
+	}
+
+	// find address with primaryid
+	var primaryAddressID string
+	var secondaryAddressID string
+	for _, addr := range cust.Addresses {
+		if addr.Type == "primary" {
+			primaryAddressID = addr.AddressID
+		} else {
+			secondaryAddressID = addr.AddressID
+		}
+	}
 
 	updateReq := updateCustomerAddressRequest{
-		Type:       "primary",
-		Address1:   "555 5th st",
-		City:       "Denver",
-		State:      "CO",
-		PostalCode: "12345",
-		Country:    "USA",
-		Validated:  true,
+		address: address{
+			Type:       "primary",
+			Address1:   "555 5th st",
+			City:       "Denver",
+			State:      "CO",
+			PostalCode: "12345",
+			Country:    "USA",
+		},
+		Validated: true,
 	}
 	payload, err := json.Marshal(updateReq)
 	require.NoError(t, err)
 
-	addressID := cust.Addresses[0].AddressID
-
 	router := mux.NewRouter()
 	AddCustomerAddressRoutes(log.NewNopLogger(), router, repo)
 
-	url := fmt.Sprintf("/customers/%s/addresses/%s", cust.CustomerID, addressID)
+	url := fmt.Sprintf("/customers/%s/addresses/%s", cust.CustomerID, primaryAddressID)
 	req, err := http.NewRequest("PUT", url, bytes.NewReader(payload))
 	require.NoError(t, err)
 
@@ -115,12 +151,17 @@ func TestCustomers__updateCustomerAddress(t *testing.T) {
 
 	res := httptest.NewRecorder()
 	router.ServeHTTP(res, req)
-	require.Equal(t, http.StatusOK, res.Code)
+	require.Equalf(t, http.StatusOK, res.Code, "response body: %s", res.Body.String())
 
 	var customerResp *client.Customer
 	require.NoError(t, json.Unmarshal(res.Body.Bytes(), &customerResp))
 
-	got := customerResp.Addresses[0]
+	var got client.CustomerAddress
+	for _, a := range customerResp.Addresses {
+		if a.AddressID == primaryAddressID {
+			got = a
+		}
+	}
 	want := client.CustomerAddress{
 		AddressID:  got.AddressID,
 		Type:       updateReq.Type,
@@ -133,6 +174,22 @@ func TestCustomers__updateCustomerAddress(t *testing.T) {
 		Validated:  updateReq.Validated,
 	}
 	require.Equal(t, want, got)
+
+	/* Error when trying to update a secondary address to primary when one already exists */
+	res = httptest.NewRecorder()
+	payload, err = json.Marshal(updateReq)
+	require.NoError(t, err)
+	url = fmt.Sprintf("/customers/%s/addresses/%s", cust.CustomerID, secondaryAddressID)
+
+	req, err = http.NewRequest("PUT", url, bytes.NewReader(payload))
+	require.NoError(t, err)
+	router.ServeHTTP(res, req)
+	require.Equal(t, http.StatusBadRequest, res.Code)
+	var errResp struct {
+		ErrorMsg string `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(res.Body.Bytes(), &errResp))
+	require.Contains(t, errResp.ErrorMsg, ErrAddressTypeDuplicate.Error())
 }
 
 func TestCustomers__deleteCustomerAddress(t *testing.T) {
@@ -214,7 +271,7 @@ func TestCustomerRepository__updateCustomerAddress(t *testing.T) {
 	err := repo.CreateCustomer(cust, "organization")
 	require.NoError(t, err)
 
-	address := address{
+	addrRequest := address{
 		Address1:   "123 1st st",
 		City:       "Denver",
 		State:      "CO",
@@ -222,20 +279,22 @@ func TestCustomerRepository__updateCustomerAddress(t *testing.T) {
 		Country:    "USA",
 		Type:       "primary",
 	}
-	require.NoError(t, repo.addCustomerAddress(cust.CustomerID, address))
+	require.NoError(t, repo.addCustomerAddress(cust.CustomerID, addrRequest))
 
 	cust, err = repo.GetCustomer(cust.CustomerID)
 	require.NoError(t, err)
 
 	addressID := cust.Addresses[0].AddressID
 	updateReq := updateCustomerAddressRequest{
-		Type:       "primary",
-		Address1:   "555 5th st",
-		City:       "Denver",
-		State:      "CO",
-		PostalCode: "12345",
-		Country:    "USA",
-		Validated:  true,
+		address: address{
+			Type:       "primary",
+			Address1:   "555 5th st",
+			City:       "Denver",
+			State:      "CO",
+			PostalCode: "12345",
+			Country:    "USA",
+		},
+		Validated: true,
 	}
 	err = repo.updateCustomerAddress(cust.CustomerID, addressID, updateReq)
 	require.NoError(t, err)

--- a/pkg/customers/approval_test.go
+++ b/pkg/customers/approval_test.go
@@ -54,26 +54,3 @@ func TestCustomers__updateCustomerStatus(t *testing.T) {
 	require.NotNil(t, customer)
 	require.Equal(t, updateStatusRequest.Status, repo.updatedStatus)
 }
-
-func TestCustomers__containsValidPrimaryAddress(t *testing.T) {
-	if containsValidPrimaryAddress(nil) {
-		t.Error("no addresses, so can't be found")
-	}
-	addresses := []client.CustomerAddress{
-		{
-			Type:      "Primary",
-			Validated: false,
-		},
-	}
-	if containsValidPrimaryAddress(addresses) {
-		t.Error("Address isn't validated")
-	}
-	addresses[0].Validated = true
-	if !containsValidPrimaryAddress(addresses) {
-		t.Error("Address should be Primary and Validated")
-	}
-	addresses[0].Type = "Secondary"
-	if containsValidPrimaryAddress(addresses) {
-		t.Error("Address is Secondary")
-	}
-}

--- a/pkg/customers/customers_test.go
+++ b/pkg/customers/customers_test.go
@@ -6,9 +6,11 @@ package customers
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -308,6 +310,7 @@ func TestCustomers__customerRequest(t *testing.T) {
 		State:      "CA",
 		PostalCode: "90210",
 		Country:    "US",
+		Type:       "primary",
 	})
 	if err := req.validate(); err != nil {
 		t.Errorf("unexpected error: %v", err)
@@ -327,7 +330,7 @@ func TestCustomers__customerRequest(t *testing.T) {
 }
 
 func TestCustomers__addressValidate(t *testing.T) {
-	add := address{}
+	add := address{Type: "primary"}
 
 	add.State = "IA"
 	if err := add.validate(); err != nil {
@@ -343,7 +346,7 @@ func TestCustomers__addressValidate(t *testing.T) {
 func TestCustomers__CreateCustomer(t *testing.T) {
 	w := httptest.NewRecorder()
 	phone := `{"number": "555.555.5555", "type": "mobile"}`
-	address := `{"type": "home", "address1": "123 1st St", "city": "Denver", "state": "CO", "postalCode": "12345", "country": "USA"}`
+	address := `{"type": "primary", "address1": "123 1st St", "city": "Denver", "state": "CO", "postalCode": "12345", "country": "USA"}`
 	body := fmt.Sprintf(`{"firstName": "jane", "lastName": "doe", "email": "jane@example.com", "birthDate": "1991-04-01", "ssn": "123456789", "type": "individual", "phones": [%s], "addresses": [%s]}`, phone, address)
 	req := httptest.NewRequest("POST", "/customers", strings.NewReader(body))
 	req.Header.Set("x-organization", "test")
@@ -428,6 +431,7 @@ func TestCustomers__updateCustomer(t *testing.T) {
 				State:      "CA",
 				PostalCode: "90210",
 				Country:    "US",
+				Type:       "primary",
 			},
 		},
 	}
@@ -459,6 +463,7 @@ func TestCustomers__updateCustomer(t *testing.T) {
 			State:      "CA",
 			PostalCode: "90210",
 			Country:    "US",
+			Type:       "primary",
 		},
 	}
 	payload, err := json.Marshal(&updateReq)
@@ -484,6 +489,38 @@ func TestCustomers__updateCustomer(t *testing.T) {
 	want.CreatedAt = got.CreatedAt
 	want.LastModified = got.LastModified
 	require.Equal(t, want, got)
+
+	/* Error when settings two addresses as primary */
+	updateReq.Addresses = []address{
+		{
+			Address1:   "555 5th st",
+			City:       "real city",
+			State:      "CA",
+			PostalCode: "90210",
+			Country:    "US",
+			Type:       "primary",
+		},
+		{
+			Address1:   "444 4th st",
+			City:       "real city",
+			State:      "CA",
+			PostalCode: "90210",
+			Country:    "US",
+			Type:       "primary",
+		},
+	}
+	payload, err = json.Marshal(&updateReq)
+	require.NoError(t, err)
+	req = req.Clone(context.Background())
+	req.Body = ioutil.NopCloser(bytes.NewReader(payload))
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	var errResp struct {
+		ErrorMsg string `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &errResp))
+	require.Contains(t, errResp.ErrorMsg, ErrAddressTypeDuplicate.Error())
 }
 
 func createTestCustomerRepository(t *testing.T) *sqlCustomerRepository {
@@ -705,7 +742,7 @@ func TestCustomersRepository__addCustomerAddress(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// add an Address
+	// add an address
 	if err := repo.addCustomerAddress(cust.CustomerID, address{
 		Address1:   "123 1st st",
 		City:       "fake city",


### PR DESCRIPTION
Ensures that a customer cannot have two address with type `primary` through the various endpoints used to create or update a customer's addresses.

Fixes #215 