### PR TITLE
return 404 for logo not found

### DIFF
--- a/pkg/configuration/router.go
+++ b/pkg/configuration/router.go
@@ -123,6 +123,9 @@ func getOrganizationLogo(logger log.Logger, repo Repository, bucketFactory stora
 			msg := "error retrieving logo file"
 			if gcerrors.Code(err) == gcerrors.NotFound {
 				msg = msg + " - file not found"
+				logger.Log("configuration", msg, "error", err, "organization", organization, "requestID", requestID)
+				http.NotFound(w, r)
+				return
 			}
 			logger.Log("configuration", msg, "error", err, "organization", organization, "requestID", requestID)
 			moovhttp.Problem(w, fmt.Errorf(msg))

--- a/pkg/configuration/router_test.go
+++ b/pkg/configuration/router_test.go
@@ -205,13 +205,7 @@ func TestRouterGetOrganizationLogo_noLogoUploaded(t *testing.T) {
 	router.ServeHTTP(w, req)
 	w.Flush()
 
-	require.Equal(t, w.Code, http.StatusBadRequest)
-	response := make(map[string]string)
-	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
-		t.Fatal(err)
-	}
-	require.Contains(t, response, "error")
-	require.Equal(t, "error retrieving logo file - file not found", response["error"])
+	require.Equal(t, http.StatusNotFound, w.Code)
 }
 
 func TestRouterUploadAndGetLogo(t *testing.T) {


### PR DESCRIPTION
This PR fixes a grievous and, in retrospect, obvious error in my previous PR (for #194). When the requested logo image file isn't found in the storage bucket, the endpoint will now respond with 404 not found.