### PR TITLE
http: add endpoint to fetch a detailed list of customer and account info

### DIFF
--- a/api/admin.yaml
+++ b/api/admin.yaml
@@ -82,7 +82,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: 'https://raw.githubusercontent.com/moov-io/api/master/openapi-common.yaml#/components/schemas/Error'
+                $ref: 'https://raw.githubusercontent.com/moov-io/base/master/api/common.yaml#/components/schemas/Error'
   /customers/{customerID}/status:
     put:
       tags: [Customers]
@@ -111,7 +111,8 @@ paths:
           content:
             application/json:
               schema:
-                $ref: 'https://raw.githubusercontent.com/moov-io/api/master/openapi-common.yaml#/components/schemas/Error'
+                $ref: 'https://raw.githubusercontent.com/moov-io/base/master/api/common.yaml#/components/schemas/Error'
+
 components:
   schemas:
     LivenessProbes:

--- a/api/client.yaml
+++ b/api/client.yaml
@@ -85,7 +85,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: 'https://raw.githubusercontent.com/moov-io/api/master/openapi-common.yaml#/components/schemas/Error'
+                $ref: 'https://raw.githubusercontent.com/moov-io/base/master/api/common.yaml#/components/schemas/Error'
   /configuration/logo:
     get:
       tags: [Configuration]
@@ -125,7 +125,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: 'https://raw.githubusercontent.com/moov-io/api/master/openapi-common.yaml#/components/schemas/Error'
+                $ref: 'https://raw.githubusercontent.com/moov-io/base/master/api/common.yaml#/components/schemas/Error'
     put:
       tags: [Configuration]
       summary: Upload organization logo
@@ -165,7 +165,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: 'https://raw.githubusercontent.com/moov-io/api/master/openapi-common.yaml#/components/schemas/Error'
+                $ref: 'https://raw.githubusercontent.com/moov-io/base/master/api/common.yaml#/components/schemas/Error'
   /customers:
     get:
       tags: [Customers]
@@ -222,7 +222,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: 'https://raw.githubusercontent.com/moov-io/api/master/openapi-common.yaml#/components/schemas/Error'
+                $ref: 'https://raw.githubusercontent.com/moov-io/base/master/api/common.yaml#/components/schemas/Error'
     post:
       tags: [Customers]
       summary: Create customer
@@ -259,7 +259,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: 'https://raw.githubusercontent.com/moov-io/api/master/openapi-common.yaml#/components/schemas/Error'
+                $ref: 'https://raw.githubusercontent.com/moov-io/base/master/api/common.yaml#/components/schemas/Error'
   /customers/{customerID}:
     get:
       tags: [Customers]
@@ -298,7 +298,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: 'https://raw.githubusercontent.com/moov-io/api/master/openapi-common.yaml#/components/schemas/Error'
+                $ref: 'https://raw.githubusercontent.com/moov-io/base/master/api/common.yaml#/components/schemas/Error'
         '404':
           description: No Customer with the specified customerID was found
     delete:
@@ -376,7 +376,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: 'https://raw.githubusercontent.com/moov-io/api/master/openapi-common.yaml#/components/schemas/Error'
+                $ref: 'https://raw.githubusercontent.com/moov-io/base/master/api/common.yaml#/components/schemas/Error'
   /customers/{customerID}/address:
     post:
       tags: [Customers]
@@ -421,7 +421,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: 'https://raw.githubusercontent.com/moov-io/api/master/openapi-common.yaml#/components/schemas/Error'
+                $ref: 'https://raw.githubusercontent.com/moov-io/base/master/api/common.yaml#/components/schemas/Error'
   /customers/{customerID}/addresses/{addressID}:
     put:
       tags: [Customers]
@@ -457,7 +457,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: 'https://raw.githubusercontent.com/moov-io/api/master/openapi-common.yaml#/components/schemas/Error'
+                $ref: 'https://raw.githubusercontent.com/moov-io/base/master/api/common.yaml#/components/schemas/Error'
     delete:
       tags: [Customers]
       summary: Delete a customer's address
@@ -486,7 +486,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: 'https://raw.githubusercontent.com/moov-io/api/master/openapi-common.yaml#/components/schemas/Error'
+                $ref: 'https://raw.githubusercontent.com/moov-io/base/master/api/common.yaml#/components/schemas/Error'
 
   /customers/{customerID}/metadata:
     put:
@@ -532,7 +532,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: 'https://raw.githubusercontent.com/moov-io/api/master/openapi-common.yaml#/components/schemas/Error'
+                $ref: 'https://raw.githubusercontent.com/moov-io/base/master/api/common.yaml#/components/schemas/Error'
   /customers/{customerID}/status:
     put:
       tags: [Customers]
@@ -577,7 +577,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: 'https://raw.githubusercontent.com/moov-io/api/master/openapi-common.yaml#/components/schemas/Error'
+                $ref: 'https://raw.githubusercontent.com/moov-io/base/master/api/common.yaml#/components/schemas/Error'
   /customers/{customerID}/accounts:
     get:
       tags: [Customers]
@@ -616,7 +616,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: 'https://raw.githubusercontent.com/moov-io/api/master/openapi-common.yaml#/components/schemas/Error'
+                $ref: 'https://raw.githubusercontent.com/moov-io/base/master/api/common.yaml#/components/schemas/Error'
     post:
       tags: [Customers]
       summary: Create Customer Account
@@ -660,7 +660,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: 'https://raw.githubusercontent.com/moov-io/api/master/openapi-common.yaml#/components/schemas/Error'
+                $ref: 'https://raw.githubusercontent.com/moov-io/base/master/api/common.yaml#/components/schemas/Error'
     delete:
       tags: [Customers]
       summary: Delete Customer Account
@@ -694,7 +694,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: 'https://raw.githubusercontent.com/moov-io/api/master/openapi-common.yaml#/components/schemas/Error'
+                $ref: 'https://raw.githubusercontent.com/moov-io/base/master/api/common.yaml#/components/schemas/Error'
   /customers/{customerID}/accounts/{accountID}:
     get:
       description: Retrieve an account by ID for the given customer.
@@ -741,7 +741,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: 'https://raw.githubusercontent.com/moov-io/api/master/openapi-common.yaml#/components/schemas/Error'
+                $ref: 'https://raw.githubusercontent.com/moov-io/base/master/api/common.yaml#/components/schemas/Error'
           description: Failed to get accounts, see error(s)
       summary: Get Customer Account by ID
       tags:
@@ -792,7 +792,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: 'https://raw.githubusercontent.com/moov-io/api/master/openapi-common.yaml#/components/schemas/Error'
+                $ref: 'https://raw.githubusercontent.com/moov-io/base/master/api/common.yaml#/components/schemas/Error'
   /customers/{customerID}/accounts/{accountID}/validations/{validationID}:
     get:
       tags: [Customers]
@@ -853,10 +853,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: 'https://raw.githubusercontent.com/moov-io/api/master/openapi-common.yaml#/components/schemas/Error'
+                $ref: 'https://raw.githubusercontent.com/moov-io/base/master/api/common.yaml#/components/schemas/Error'
   /customers/{customerID}/accounts/{accountID}/ofac:
     get:
-      tags: [ Customers ]
+      tags: [Customers]
       summary: Latest Account OFAC search
       description: Get the latest OFAC search for an Account
       operationId: getLatestAccountOFACSearch
@@ -899,10 +899,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: 'https://raw.githubusercontent.com/moov-io/api/master/openapi-common.yaml#/components/schemas/Error'
+                $ref: 'https://raw.githubusercontent.com/moov-io/base/master/api/common.yaml#/components/schemas/Error'
   /customers/{customerID}/accounts/{accountID}/refresh/ofac:
     put:
-      tags: [ Customers ]
+      tags: [Customers]
       summary: Refresh Account OFAC search
       description: Refresh OFAC search for a given Account
       operationId: refreshAccountOFACSearch
@@ -945,10 +945,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: 'https://raw.githubusercontent.com/moov-io/api/master/openapi-common.yaml#/components/schemas/Error'
+                $ref: 'https://raw.githubusercontent.com/moov-io/base/master/api/common.yaml#/components/schemas/Error'
   /customers/{customerID}/accounts/{accountID}/status:
     put:
-      tags: [ Customers ]
+      tags: [Customers]
       summary: Update Account Status
       description: Update the status for the specified accountID
       operationId: updateAccountStatus
@@ -985,7 +985,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: 'https://raw.githubusercontent.com/moov-io/api/master/openapi-common.yaml#/components/schemas/Error'
+                $ref: 'https://raw.githubusercontent.com/moov-io/base/master/api/common.yaml#/components/schemas/Error'
   /customers/{customerID}/accounts/{accountID}/validations:
     post:
       tags: [Customers]
@@ -1073,7 +1073,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: 'https://raw.githubusercontent.com/moov-io/api/master/openapi-common.yaml#/components/schemas/Error'
+                $ref: 'https://raw.githubusercontent.com/moov-io/base/master/api/common.yaml#/components/schemas/Error'
     put:
       tags: [Customers]
       summary: Complete Account Validation
@@ -1156,7 +1156,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: 'https://raw.githubusercontent.com/moov-io/api/master/openapi-common.yaml#/components/schemas/Error'
+                $ref: 'https://raw.githubusercontent.com/moov-io/base/master/api/common.yaml#/components/schemas/Error'
   /customers/{customerID}/disclaimers:
     get:
       tags: [Customers]
@@ -1195,7 +1195,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: 'https://raw.githubusercontent.com/moov-io/api/master/openapi-common.yaml#/components/schemas/Error'
+                $ref: 'https://raw.githubusercontent.com/moov-io/base/master/api/common.yaml#/components/schemas/Error'
   /customers/{customerID}/disclaimers/{disclaimerID}:
     post:
       tags: [Customers]
@@ -1241,7 +1241,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: 'https://raw.githubusercontent.com/moov-io/api/master/openapi-common.yaml#/components/schemas/Error'
+                $ref: 'https://raw.githubusercontent.com/moov-io/base/master/api/common.yaml#/components/schemas/Error'
   /customers/{customerID}/documents:
     post:
       tags: [Customers]
@@ -1298,7 +1298,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: 'https://raw.githubusercontent.com/moov-io/api/master/openapi-common.yaml#/components/schemas/Error'
+                $ref: 'https://raw.githubusercontent.com/moov-io/base/master/api/common.yaml#/components/schemas/Error'
     get:
       tags: [Customers]
       summary: Get customer documents
@@ -1336,7 +1336,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: 'https://raw.githubusercontent.com/moov-io/api/master/openapi-common.yaml#/components/schemas/Error'
+                $ref: 'https://raw.githubusercontent.com/moov-io/base/master/api/common.yaml#/components/schemas/Error'
   /customers/{customerID}/documents/{documentID}:
     get:
       tags: [Customers]
@@ -1387,7 +1387,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: 'https://raw.githubusercontent.com/moov-io/api/master/openapi-common.yaml#/components/schemas/Error'
+                $ref: 'https://raw.githubusercontent.com/moov-io/base/master/api/common.yaml#/components/schemas/Error'
     delete:
       description: Remove a customer's document
       operationId: deleteCustomerDocument
@@ -1422,7 +1422,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: 'https://raw.githubusercontent.com/moov-io/api/master/openapi-common.yaml#/components/schemas/Error'
+                $ref: 'https://raw.githubusercontent.com/moov-io/base/master/api/common.yaml#/components/schemas/Error'
       summary: Delete a customer's document
       tags:
         - Customers
@@ -1464,7 +1464,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: 'https://raw.githubusercontent.com/moov-io/api/master/openapi-common.yaml#/components/schemas/Error'
+                $ref: 'https://raw.githubusercontent.com/moov-io/base/master/api/common.yaml#/components/schemas/Error'
   /customers/{customerID}/refresh/ofac:
     put:
       tags: [Customers]
@@ -1503,8 +1503,39 @@ paths:
           content:
             application/json:
               schema:
-                $ref: 'https://raw.githubusercontent.com/moov-io/api/master/openapi-common.yaml#/components/schemas/Error'
-
+                $ref: 'https://raw.githubusercontent.com/moov-io/base/master/api/common.yaml#/components/schemas/Error'
+  /reports/accounts:
+    get:
+      tags: [Customers]
+      description: Retrieves a list of customer and account information.
+      operationId: getReportOfCustomerAccounts
+      parameters:
+        - name: X-Request-ID
+          in: header
+          description: Optional requestID allows application developer to trace requests through the systems logs
+          example: rs4f9915
+          schema:
+            type: string
+        - name: accountIDs
+          in: query
+          description: A list of customer account IDs with a limit of 25 IDs.
+          example: f6eddffd,f6eddffe,f6eddfff
+          schema:
+            type: string
+          required: false
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReportAccountResponse'
+          description: A list of customers' accounts
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: 'https://raw.githubusercontent.com/moov-io/base/master/api/common.yaml#/components/schemas/Error'
+          description: Failed to get accounts, see error(s)
 components:
   schemas:
     OrganizationConfiguration:
@@ -1895,6 +1926,10 @@ components:
           type: string
           description: A unique identifier for this account
           example: e1b1544a
+        customerID:
+          type: string
+          description: The unique identifier for the customer who owns the account
+          example: e1b1544a
         holderName:
           type: string
           description: Legal holder name on the account
@@ -1915,6 +1950,7 @@ components:
           $ref: '#/components/schemas/InstitutionDetails'
       required:
         - accountID
+        - customerID
         - holderName
         - maskedAccountNumber
         - routingNumber
@@ -2197,3 +2233,10 @@ components:
           $ref: 'https://raw.githubusercontent.com/moov-io/customers/master/api/client.yaml#/components/schemas/AccountStatus'
       required:
         - status
+    ReportAccountResponse:
+      type: object
+      properties:
+        Customer:
+          $ref: '#/components/schemas/Customer'
+        Account:
+          $ref: '#/components/schemas/Account'

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/moov-io/customers/pkg/documents/storage"
 	"github.com/moov-io/customers/pkg/fed"
 	"github.com/moov-io/customers/pkg/paygate"
+	"github.com/moov-io/customers/pkg/reports"
 	"github.com/moov-io/customers/pkg/secrets"
 	"github.com/moov-io/customers/pkg/validator"
 	"github.com/moov-io/customers/pkg/validator/microdeposits"
@@ -177,6 +178,7 @@ func main() {
 	documents.AddDisclaimerRoutes(logger, router, disclaimerRepo)
 	documents.AddDocumentRoutes(logger, router, documentRepo, bucket)
 	customers.AddOFACRoutes(logger, router, customerRepo, ofac)
+	reports.AddRoutes(logger, router, customerRepo, accountsRepo)
 
 	// Add Configuration routes
 	configRepo := configuration.NewRepository(db)

--- a/pkg/accounts/mock_repository.go
+++ b/pkg/accounts/mock_repository.go
@@ -8,6 +8,8 @@ import (
 	"github.com/moov-io/customers/pkg/client"
 )
 
+var _ Repository = (*mockRepository)(nil)
+
 type mockRepository struct {
 	Accounts      []*client.Account
 	AccountNumber string
@@ -24,14 +26,21 @@ func (r *mockRepository) getCustomerAccount(customerID, accountID string) (*clie
 	return nil, nil
 }
 
-func (r *mockRepository) getCustomerAccounts(customerID string) ([]*client.Account, error) {
+func (r *mockRepository) GetCustomerAccountsByIDs(accountIDs []string) ([]*client.Account, error) {
 	if r.Err != nil {
 		return nil, r.Err
 	}
 	return r.Accounts, nil
 }
 
-func (r *mockRepository) createCustomerAccount(customerID, userID string, req *createAccountRequest) (*client.Account, error) {
+func (r *mockRepository) getAccountsByCustomerID(customerID string) ([]*client.Account, error) {
+	if r.Err != nil {
+		return nil, r.Err
+	}
+	return r.Accounts, nil
+}
+
+func (r *mockRepository) CreateCustomerAccount(customerID, userID string, req *CreateAccountRequest) (*client.Account, error) {
 	if r.Err != nil {
 		return nil, r.Err
 	}

--- a/pkg/accounts/router_test.go
+++ b/pkg/accounts/router_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 
 	"github.com/moov-io/base"
+
 	"github.com/moov-io/customers/internal/testclient"
 	"github.com/moov-io/customers/pkg/client"
 	"github.com/moov-io/customers/pkg/fed"
@@ -131,7 +132,7 @@ func TestRefreshAccountAndCheckAccountOfacSearch(t *testing.T) {
 }
 
 func TestAccountCreationRequest(t *testing.T) {
-	req := &createAccountRequest{}
+	req := &CreateAccountRequest{}
 	if err := req.validate(); err == nil {
 		t.Error("expected error")
 	}
@@ -167,7 +168,7 @@ func TestGetAccountByID(t *testing.T) {
 	var err error
 	for i := 0; i < 5; i++ {
 		accounts = append(accounts, &account{customerID: base.ID()})
-		accounts[i].Account, err = repo.createCustomerAccount(accounts[i].customerID, base.ID(), &createAccountRequest{
+		accounts[i].Account, err = repo.CreateCustomerAccount(accounts[i].customerID, base.ID(), &CreateAccountRequest{
 			AccountNumber: fmt.Sprintf("%d", i),
 			RoutingNumber: "987654320",
 			Type:          client.CHECKING,
@@ -317,7 +318,7 @@ func httpReadAccounts(t *testing.T, handler *mux.Router, customerID string) []*c
 }
 
 func httpCreateAccount(t *testing.T, handler *mux.Router, customerID string) *client.Account {
-	params := &createAccountRequest{
+	params := &CreateAccountRequest{
 		HolderName:    "John Doe",
 		AccountNumber: "18749",
 		RoutingNumber: "987654320",

--- a/pkg/accounts/validate_test.go
+++ b/pkg/accounts/validate_test.go
@@ -14,14 +14,15 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/moov-io/base"
+	payclient "github.com/moov-io/paygate/pkg/client"
+	"github.com/stretchr/testify/require"
+
 	"github.com/moov-io/customers/pkg/client"
 	"github.com/moov-io/customers/pkg/paygate"
 	"github.com/moov-io/customers/pkg/secrets"
 	"github.com/moov-io/customers/pkg/validator"
 	"github.com/moov-io/customers/pkg/validator/microdeposits"
 	"github.com/moov-io/customers/pkg/validator/testvalidator"
-	payclient "github.com/moov-io/paygate/pkg/client"
-	"github.com/stretchr/testify/require"
 
 	"github.com/go-kit/kit/log"
 	"github.com/gorilla/mux"
@@ -33,7 +34,7 @@ func TestRouter__AccountValidation(t *testing.T) {
 	validations := &validator.MockRepository{}
 
 	// create account
-	acc, err := accounts.createCustomerAccount(customerID, userID, &createAccountRequest{
+	acc, err := accounts.CreateCustomerAccount(customerID, userID, &CreateAccountRequest{
 		AccountNumber: "123",
 		RoutingNumber: "987654320",
 		Type:          client.CHECKING,
@@ -103,7 +104,7 @@ func TestRouter__InitAccountValidation(t *testing.T) {
 	}
 
 	// create account
-	acc, err := accounts.createCustomerAccount(customerID, userID, &createAccountRequest{
+	acc, err := accounts.CreateCustomerAccount(customerID, userID, &CreateAccountRequest{
 		AccountNumber: "123",
 		RoutingNumber: "987654320",
 		Type:          client.CHECKING,
@@ -111,7 +112,7 @@ func TestRouter__InitAccountValidation(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("Test when account is validated already", func(t *testing.T) {
-		acc, err := accounts.createCustomerAccount(customerID, userID, &createAccountRequest{
+		acc, err := accounts.CreateCustomerAccount(customerID, userID, &CreateAccountRequest{
 			AccountNumber: "1234",
 			RoutingNumber: "987654321",
 			Type:          client.CHECKING,
@@ -252,7 +253,7 @@ func TestRouter__CompleteAccountValidation(t *testing.T) {
 		{Strategy: "test", Vendor: "moov"}: testvalidator.NewStrategy(),
 	}
 
-	acc, err := repo.createCustomerAccount(customerID, userID, &createAccountRequest{
+	acc, err := repo.CreateCustomerAccount(customerID, userID, &CreateAccountRequest{
 		AccountNumber: "123456",
 		RoutingNumber: "987654323",
 		Type:          client.CHECKING,
@@ -260,7 +261,7 @@ func TestRouter__CompleteAccountValidation(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("Test when account is validated already", func(t *testing.T) {
-		acc, err := repo.createCustomerAccount(customerID, userID, &createAccountRequest{
+		acc, err := repo.CreateCustomerAccount(customerID, userID, &CreateAccountRequest{
 			AccountNumber: "123",
 			RoutingNumber: "987654320",
 			Type:          client.CHECKING,
@@ -351,7 +352,7 @@ func TestRouter__CompleteAccountValidation(t *testing.T) {
 		encrypted, err := keeper.EncryptString("1234")
 		require.NoError(t, err)
 
-		acc, err := repo.createCustomerAccount(customerID, userID, &createAccountRequest{
+		acc, err := repo.CreateCustomerAccount(customerID, userID, &CreateAccountRequest{
 			AccountNumber:          "1234",
 			RoutingNumber:          "987654321",
 			Type:                   client.CHECKING,
@@ -421,7 +422,7 @@ func TestRouter__CompleteAccountValidation(t *testing.T) {
 		encrypted, err := keeper.EncryptString("12345")
 		require.NoError(t, err)
 
-		acc, err := repo.createCustomerAccount(customerID, userID, &createAccountRequest{
+		acc, err := repo.CreateCustomerAccount(customerID, userID, &CreateAccountRequest{
 			AccountNumber:          "12345",
 			RoutingNumber:          "987654322",
 			Type:                   client.CHECKING,

--- a/pkg/client/README.md
+++ b/pkg/client/README.md
@@ -61,6 +61,7 @@ Class | Method | HTTP request | Description
 *CustomersApi* | [**GetCustomerDocuments**](docs/CustomersApi.md#getcustomerdocuments) | **Get** /customers/{customerID}/documents | Get customer documents
 *CustomersApi* | [**GetLatestAccountOFACSearch**](docs/CustomersApi.md#getlatestaccountofacsearch) | **Get** /customers/{customerID}/accounts/{accountID}/ofac | Latest Account OFAC search
 *CustomersApi* | [**GetLatestOFACSearch**](docs/CustomersApi.md#getlatestofacsearch) | **Get** /customers/{customerID}/ofac | Latest Customer OFAC search
+*CustomersApi* | [**GetReportOfCustomerAccounts**](docs/CustomersApi.md#getreportofcustomeraccounts) | **Get** /reports/accounts | 
 *CustomersApi* | [**InitAccountValidation**](docs/CustomersApi.md#initaccountvalidation) | **Post** /customers/{customerID}/accounts/{accountID}/validations | Initiate Account Validation
 *CustomersApi* | [**Ping**](docs/CustomersApi.md#ping) | **Get** /ping | Ping Customers
 *CustomersApi* | [**RefreshAccountOFACSearch**](docs/CustomersApi.md#refreshaccountofacsearch) | **Put** /customers/{customerID}/accounts/{accountID}/refresh/ofac | Refresh Account OFAC search
@@ -101,6 +102,7 @@ Class | Method | HTTP request | Description
  - [OfacSearch](docs/OfacSearch.md)
  - [OrganizationConfiguration](docs/OrganizationConfiguration.md)
  - [Phone](docs/Phone.md)
+ - [ReportAccountResponse](docs/ReportAccountResponse.md)
  - [TransitAccountNumber](docs/TransitAccountNumber.md)
  - [UpdateAccountStatus](docs/UpdateAccountStatus.md)
  - [UpdateCustomerAddress](docs/UpdateCustomerAddress.md)

--- a/pkg/client/api/openapi.yaml
+++ b/pkg/client/api/openapi.yaml
@@ -1814,6 +1814,45 @@ paths:
       summary: Refresh Customer OFAC search
       tags:
       - Customers
+  /reports/accounts:
+    get:
+      description: Retrieves a list of customer and account information.
+      operationId: getReportOfCustomerAccounts
+      parameters:
+      - description: Optional requestID allows application developer to trace requests
+          through the systems logs
+        example: rs4f9915
+        explode: false
+        in: header
+        name: X-Request-ID
+        required: false
+        schema:
+          type: string
+        style: simple
+      - description: A list of customer account IDs with a limit of 25 IDs.
+        example: f6eddffd,f6eddffe,f6eddfff
+        explode: true
+        in: query
+        name: accountIDs
+        required: false
+        schema:
+          type: string
+        style: form
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReportAccountResponse'
+          description: A list of customers' accounts
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Failed to get accounts, see error(s)
+      tags:
+      - Customers
 components:
   schemas:
     OrganizationConfiguration:
@@ -2336,12 +2375,17 @@ components:
             state: OH
           name: First Bank
         holderName: My Company,llc or Wade Arnold
+        customerID: e1b1544a
         type: checking
         maskedAccountNumber: "0001027028"
         status: validated
       properties:
         accountID:
           description: A unique identifier for this account
+          example: e1b1544a
+          type: string
+        customerID:
+          description: The unique identifier for the customer who owns the account
           example: e1b1544a
           type: string
         holderName:
@@ -2364,6 +2408,7 @@ components:
           $ref: '#/components/schemas/InstitutionDetails'
       required:
       - accountID
+      - customerID
       - holderName
       - maskedAccountNumber
       - routingNumber
@@ -2715,6 +2760,71 @@ components:
           $ref: '#/components/schemas/AccountStatus'
       required:
       - status
+    ReportAccountResponse:
+      example:
+        Account:
+          accountID: e1b1544a
+          routingNumber: "051504597"
+          institution:
+            routingNumber: "123456780"
+            phoneNumber: "5551112222"
+            address:
+              zip: "43724"
+              address2: address2
+              city: CALDWELL
+              address1: 430 NORTH ST
+              state: OH
+            name: First Bank
+          holderName: My Company,llc or Wade Arnold
+          customerID: e1b1544a
+          type: checking
+          maskedAccountNumber: "0001027028"
+          status: validated
+        Customer:
+          lastName: Smith
+          addresses:
+          - country: US
+            validated: true
+            address2: address2
+            city: city
+            address1: address1
+            postalCode: postalCode
+            state: state
+            type: Primary
+            addressID: 851233a1
+          - country: US
+            validated: true
+            address2: address2
+            city: city
+            address1: address1
+            postalCode: postalCode
+            state: state
+            type: Primary
+            addressID: 851233a1
+          metadata:
+            paygateID: 23beb5fd
+          nickName: Bob
+          phones:
+          - valid: true
+            number: +1.818.555.1212
+            type: Home
+          - valid: true
+            number: +1.818.555.1212
+            type: Home
+          suffix: suffix
+          birthDate: 2016-08-29
+          firstName: Robert
+          createdAt: 2016-08-29T09:12:33.001Z
+          customerID: e210a9d6
+          middleName: Flex
+          lastModified: 2016-08-29T09:12:33.001Z
+          email: email
+      properties:
+        Customer:
+          $ref: '#/components/schemas/Customer'
+        Account:
+          $ref: '#/components/schemas/Account'
+      type: object
     Error:
       properties:
         error:

--- a/pkg/client/api_customers.go
+++ b/pkg/client/api_customers.go
@@ -1932,6 +1932,105 @@ func (a *CustomersApiService) GetLatestOFACSearch(ctx _context.Context, customer
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
+// GetReportOfCustomerAccountsOpts Optional parameters for the method 'GetReportOfCustomerAccounts'
+type GetReportOfCustomerAccountsOpts struct {
+	XRequestID optional.String
+	AccountIDs optional.String
+}
+
+/*
+GetReportOfCustomerAccounts Method for GetReportOfCustomerAccounts
+Retrieves a list of customer and account information.
+ * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param optional nil or *GetReportOfCustomerAccountsOpts - Optional Parameters:
+ * @param "XRequestID" (optional.String) -  Optional requestID allows application developer to trace requests through the systems logs
+ * @param "AccountIDs" (optional.String) -  A list of customer account IDs with a limit of 25 IDs.
+@return ReportAccountResponse
+*/
+func (a *CustomersApiService) GetReportOfCustomerAccounts(ctx _context.Context, localVarOptionals *GetReportOfCustomerAccountsOpts) (ReportAccountResponse, *_nethttp.Response, error) {
+	var (
+		localVarHTTPMethod   = _nethttp.MethodGet
+		localVarPostBody     interface{}
+		localVarFormFileName string
+		localVarFileName     string
+		localVarFileBytes    []byte
+		localVarReturnValue  ReportAccountResponse
+	)
+
+	// create path and map variables
+	localVarPath := a.client.cfg.BasePath + "/reports/accounts"
+	localVarHeaderParams := make(map[string]string)
+	localVarQueryParams := _neturl.Values{}
+	localVarFormParams := _neturl.Values{}
+
+	if localVarOptionals != nil && localVarOptionals.AccountIDs.IsSet() {
+		localVarQueryParams.Add("accountIDs", parameterToString(localVarOptionals.AccountIDs.Value(), ""))
+	}
+	// to determine the Content-Type header
+	localVarHTTPContentTypes := []string{}
+
+	// set Content-Type header
+	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
+	if localVarHTTPContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHTTPContentType
+	}
+
+	// to determine the Accept header
+	localVarHTTPHeaderAccepts := []string{"application/json"}
+
+	// set Accept header
+	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
+	if localVarHTTPHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
+	}
+	if localVarOptionals != nil && localVarOptionals.XRequestID.IsSet() {
+		localVarHeaderParams["X-Request-ID"] = parameterToString(localVarOptionals.XRequestID.Value(), "")
+	}
+	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+
+	localVarHTTPResponse, err := a.client.callAPI(r)
+	if err != nil || localVarHTTPResponse == nil {
+		return localVarReturnValue, localVarHTTPResponse, err
+	}
+
+	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarHTTPResponse.Body.Close()
+	if err != nil {
+		return localVarReturnValue, localVarHTTPResponse, err
+	}
+
+	if localVarHTTPResponse.StatusCode >= 300 {
+		newErr := GenericOpenAPIError{
+			body:  localVarBody,
+			error: localVarHTTPResponse.Status,
+		}
+		if localVarHTTPResponse.StatusCode == 400 {
+			var v Error
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			newErr.model = v
+		}
+		return localVarReturnValue, localVarHTTPResponse, newErr
+	}
+
+	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	if err != nil {
+		newErr := GenericOpenAPIError{
+			body:  localVarBody,
+			error: err.Error(),
+		}
+		return localVarReturnValue, localVarHTTPResponse, newErr
+	}
+
+	return localVarReturnValue, localVarHTTPResponse, nil
+}
+
 // InitAccountValidationOpts Optional parameters for the method 'InitAccountValidation'
 type InitAccountValidationOpts struct {
 	XRequestID    optional.String

--- a/pkg/client/docs/Account.md
+++ b/pkg/client/docs/Account.md
@@ -5,6 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **AccountID** | **string** | A unique identifier for this account | 
+**CustomerID** | **string** | The unique identifier for the customer who owns the account | 
 **HolderName** | **string** | Legal holder name on the account | 
 **MaskedAccountNumber** | **string** | The masked account number for the bank account | 
 **RoutingNumber** | **string** | The ABA routing transit number for the bank account. | 

--- a/pkg/client/docs/CustomersApi.md
+++ b/pkg/client/docs/CustomersApi.md
@@ -23,6 +23,7 @@ Method | HTTP request | Description
 [**GetCustomerDocuments**](CustomersApi.md#GetCustomerDocuments) | **Get** /customers/{customerID}/documents | Get customer documents
 [**GetLatestAccountOFACSearch**](CustomersApi.md#GetLatestAccountOFACSearch) | **Get** /customers/{customerID}/accounts/{accountID}/ofac | Latest Account OFAC search
 [**GetLatestOFACSearch**](CustomersApi.md#GetLatestOFACSearch) | **Get** /customers/{customerID}/ofac | Latest Customer OFAC search
+[**GetReportOfCustomerAccounts**](CustomersApi.md#GetReportOfCustomerAccounts) | **Get** /reports/accounts | 
 [**InitAccountValidation**](CustomersApi.md#InitAccountValidation) | **Post** /customers/{customerID}/accounts/{accountID}/validations | Initiate Account Validation
 [**Ping**](CustomersApi.md#Ping) | **Get** /ping | Ping Customers
 [**RefreshAccountOFACSearch**](CustomersApi.md#RefreshAccountOFACSearch) | **Put** /customers/{customerID}/accounts/{accountID}/refresh/ofac | Refresh Account OFAC search
@@ -908,6 +909,50 @@ Name | Type | Description  | Notes
 ### Return type
 
 [**OfacSearch**](OFACSearch.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints)
+[[Back to Model list]](../README.md#documentation-for-models)
+[[Back to README]](../README.md)
+
+
+## GetReportOfCustomerAccounts
+
+> ReportAccountResponse GetReportOfCustomerAccounts(ctx, optional)
+
+
+
+Retrieves a list of customer and account information.
+
+### Required Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
+ **optional** | ***GetReportOfCustomerAccountsOpts** | optional parameters | nil if no parameters
+
+### Optional Parameters
+
+Optional parameters are passed through a pointer to a GetReportOfCustomerAccountsOpts struct
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **xRequestID** | **optional.String**| Optional requestID allows application developer to trace requests through the systems logs | 
+ **accountIDs** | **optional.String**| A list of customer account IDs with a limit of 25 IDs. | 
+
+### Return type
+
+[**ReportAccountResponse**](ReportAccountResponse.md)
 
 ### Authorization
 

--- a/pkg/client/docs/ReportAccountResponse.md
+++ b/pkg/client/docs/ReportAccountResponse.md
@@ -1,0 +1,12 @@
+# ReportAccountResponse
+
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**Customer** | [**Customer**](Customer.md) |  | [optional] 
+**Account** | [**Account**](Account.md) |  | [optional] 
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+

--- a/pkg/client/model_report_account_response.go
+++ b/pkg/client/model_report_account_response.go
@@ -9,19 +9,8 @@
 
 package client
 
-// Account struct for Account
-type Account struct {
-	// A unique identifier for this account
-	AccountID string `json:"accountID"`
-	// The unique identifier for the customer who owns the account
-	CustomerID string `json:"customerID"`
-	// Legal holder name on the account
-	HolderName string `json:"holderName"`
-	// The masked account number for the bank account
-	MaskedAccountNumber string `json:"maskedAccountNumber"`
-	// The ABA routing transit number for the bank account.
-	RoutingNumber string             `json:"routingNumber"`
-	Status        AccountStatus      `json:"status"`
-	Type          AccountType        `json:"type"`
-	Institution   InstitutionDetails `json:"institution,omitempty"`
+// ReportAccountResponse struct for ReportAccountResponse
+type ReportAccountResponse struct {
+	Customer Customer `json:"Customer,omitempty"`
+	Account  Account  `json:"Account,omitempty"`
 }

--- a/pkg/customers/address_test.go
+++ b/pkg/customers/address_test.go
@@ -24,7 +24,7 @@ func TestCustomers__addCustomerAddress(t *testing.T) {
 		LastName:  "Doe",
 	}
 	cust, _, _ := customerRequest.asCustomer(testCustomerSSNStorage(t))
-	err := repo.createCustomer(cust, "organization")
+	err := repo.CreateCustomer(cust, "organization")
 	require.NoError(t, err)
 
 	address := address{
@@ -74,7 +74,7 @@ func TestCustomers__updateCustomerAddress(t *testing.T) {
 		LastName:  "Doe",
 	}
 	cust, _, _ := customerRequest.asCustomer(testCustomerSSNStorage(t))
-	err := repo.createCustomer(cust, "organization")
+	err := repo.CreateCustomer(cust, "organization")
 	require.NoError(t, err)
 
 	address := address{
@@ -86,7 +86,7 @@ func TestCustomers__updateCustomerAddress(t *testing.T) {
 		Type:       "primary",
 	}
 	require.NoError(t, repo.addCustomerAddress(cust.CustomerID, address))
-	cust, err = repo.getCustomer(cust.CustomerID) // refresh customer object after updating address
+	cust, err = repo.GetCustomer(cust.CustomerID) // refresh customer object after updating address
 	require.NoError(t, err)
 
 	updateReq := updateCustomerAddressRequest{
@@ -144,7 +144,7 @@ func TestCustomers__deleteCustomerAddress(t *testing.T) {
 		LastName:  "Doe",
 	}
 	cust, _, _ := customerRequest.asCustomer(testCustomerSSNStorage(t))
-	err := repo.createCustomer(cust, "organization")
+	err := repo.CreateCustomer(cust, "organization")
 	require.NoError(t, err)
 
 	address := address{
@@ -157,7 +157,7 @@ func TestCustomers__deleteCustomerAddress(t *testing.T) {
 	}
 	require.NoError(t, repo.addCustomerAddress(cust.CustomerID, address))
 
-	cust, err = repo.getCustomer(cust.CustomerID)
+	cust, err = repo.GetCustomer(cust.CustomerID)
 	require.NoError(t, err)
 	addressID := cust.Addresses[0].AddressID
 
@@ -174,7 +174,7 @@ func TestCustomers__deleteCustomerAddress(t *testing.T) {
 	router.ServeHTTP(res, req)
 	require.Equal(t, http.StatusNoContent, res.Code)
 
-	cust, err = repo.getCustomer(cust.CustomerID)
+	cust, err = repo.GetCustomer(cust.CustomerID)
 	require.NoError(t, err)
 	require.Empty(t, cust.Addresses)
 }
@@ -211,7 +211,7 @@ func TestCustomerRepository__updateCustomerAddress(t *testing.T) {
 		LastName:  "Doe",
 	}
 	cust, _, _ := customerRequest.asCustomer(testCustomerSSNStorage(t))
-	err := repo.createCustomer(cust, "organization")
+	err := repo.CreateCustomer(cust, "organization")
 	require.NoError(t, err)
 
 	address := address{
@@ -224,7 +224,7 @@ func TestCustomerRepository__updateCustomerAddress(t *testing.T) {
 	}
 	require.NoError(t, repo.addCustomerAddress(cust.CustomerID, address))
 
-	cust, err = repo.getCustomer(cust.CustomerID)
+	cust, err = repo.GetCustomer(cust.CustomerID)
 	require.NoError(t, err)
 
 	addressID := cust.Addresses[0].AddressID
@@ -240,7 +240,7 @@ func TestCustomerRepository__updateCustomerAddress(t *testing.T) {
 	err = repo.updateCustomerAddress(cust.CustomerID, addressID, updateReq)
 	require.NoError(t, err)
 
-	cust, err = repo.getCustomer(cust.CustomerID)
+	cust, err = repo.GetCustomer(cust.CustomerID)
 	require.NoError(t, err)
 
 	require.Len(t, cust.Addresses, 1)
@@ -268,7 +268,7 @@ func TestCustomerRepository__deleteCustomerAddress(t *testing.T) {
 		LastName:  "Doe",
 	}
 	cust, _, _ := customerRequest.asCustomer(testCustomerSSNStorage(t))
-	err := repo.createCustomer(cust, "organization")
+	err := repo.CreateCustomer(cust, "organization")
 	require.NoError(t, err)
 
 	address := address{
@@ -281,14 +281,14 @@ func TestCustomerRepository__deleteCustomerAddress(t *testing.T) {
 	}
 	require.NoError(t, repo.addCustomerAddress(cust.CustomerID, address))
 
-	cust, err = repo.getCustomer(cust.CustomerID)
+	cust, err = repo.GetCustomer(cust.CustomerID)
 	require.NoError(t, err)
 
 	addressID := cust.Addresses[0].AddressID
 	err = repo.deleteCustomerAddress(cust.CustomerID, addressID)
 	require.NoError(t, err)
 
-	cust, err = repo.getCustomer(cust.CustomerID)
+	cust, err = repo.GetCustomer(cust.CustomerID)
 	require.NoError(t, err)
 
 	require.Len(t, cust.Addresses, 0)

--- a/pkg/customers/approval.go
+++ b/pkg/customers/approval.go
@@ -74,7 +74,7 @@ func updateCustomerStatus(logger log.Logger, repo CustomerRepository, customerSS
 			return
 		}
 
-		cust, err := repo.getCustomer(customerID)
+		cust, err := repo.GetCustomer(customerID)
 		if err != nil {
 			moovhttp.Problem(w, err)
 			return

--- a/pkg/customers/approval_ofac.go
+++ b/pkg/customers/approval_ofac.go
@@ -13,10 +13,11 @@ import (
 	"time"
 
 	moovhttp "github.com/moov-io/base/http"
+	watchmanClient "github.com/moov-io/watchman/client"
+
 	"github.com/moov-io/customers/pkg/client"
 	"github.com/moov-io/customers/pkg/route"
 	"github.com/moov-io/customers/pkg/watchman"
-	watchmanClient "github.com/moov-io/watchman/client"
 
 	"github.com/go-kit/kit/log"
 	"github.com/gorilla/mux"
@@ -125,7 +126,7 @@ func refreshOFACSearch(logger log.Logger, repo CustomerRepository, ofac *OFACSea
 			return
 		}
 
-		cust, err := repo.getCustomer(customerID)
+		cust, err := repo.GetCustomer(customerID)
 		if err != nil {
 			moovhttp.Problem(w, err)
 			return

--- a/pkg/customers/customer_search.go
+++ b/pkg/customers/customer_search.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/go-kit/kit/log"
 	moovhttp "github.com/moov-io/base/http"
+
 	"github.com/moov-io/customers/pkg/client"
 	"github.com/moov-io/customers/pkg/route"
 )
@@ -46,7 +47,7 @@ func searchCustomers(logger log.Logger, repo CustomerRepository) http.HandlerFun
 	}
 }
 
-type searchParams struct {
+type SearchParams struct {
 	Organization string
 	Query        string
 	Email        string
@@ -56,8 +57,8 @@ type searchParams struct {
 	Count        int64
 }
 
-func readSearchParams(r *http.Request) (searchParams, error) {
-	params := searchParams{
+func readSearchParams(r *http.Request) (SearchParams, error) {
+	params := SearchParams{
 		Query:  strings.ToLower(strings.TrimSpace(r.URL.Query().Get("query"))),
 		Email:  strings.ToLower(strings.TrimSpace(r.URL.Query().Get("email"))),
 		Status: strings.ToLower(strings.TrimSpace(r.URL.Query().Get("status"))),
@@ -74,7 +75,7 @@ func readSearchParams(r *http.Request) (searchParams, error) {
 	return params, nil
 }
 
-func (r *sqlCustomerRepository) searchCustomers(params searchParams) ([]*client.Customer, error) {
+func (r *sqlCustomerRepository) searchCustomers(params SearchParams) ([]*client.Customer, error) {
 	query, args := buildSearchQuery(params)
 
 	stmt, err := r.db.Prepare(query)
@@ -102,7 +103,7 @@ func (r *sqlCustomerRepository) searchCustomers(params searchParams) ([]*client.
 
 	// Read each Customer
 	for i := range customerIDs {
-		cust, err := r.getCustomer(customerIDs[i])
+		cust, err := r.GetCustomer(customerIDs[i])
 		if err != nil {
 			return customers, fmt.Errorf("search: customerID=%s error=%v", customerIDs[i], err)
 		}
@@ -111,7 +112,7 @@ func (r *sqlCustomerRepository) searchCustomers(params searchParams) ([]*client.
 	return customers, nil
 }
 
-func buildSearchQuery(params searchParams) (string, []interface{}) {
+func buildSearchQuery(params SearchParams) (string, []interface{}) {
 	var args []interface{}
 	query := `select customer_id from customers where deleted_at is null and organization = ?`
 	args = append(args, params.Organization)

--- a/pkg/customers/customer_search_scope_test.go
+++ b/pkg/customers/customer_search_scope_test.go
@@ -66,7 +66,7 @@ func (scope *Scope) CreateCustomer(firstName, lastName, email string, customerTy
 		Email:     email,
 		Type:      customerType,
 	}).asCustomer(testCustomerSSNStorage(scope.t))
-	if err := scope.customerRepo.createCustomer(cust, "organization"); err != nil {
+	if err := scope.customerRepo.CreateCustomer(cust, "organization"); err != nil {
 		scope.t.Error(err)
 	}
 	return *cust

--- a/pkg/customers/customer_search_test.go
+++ b/pkg/customers/customer_search_test.go
@@ -44,7 +44,7 @@ func TestCustomersSearchRouter(t *testing.T) {
 		LastName:  "Doe",
 		Email:     "jane@example.com",
 	}).asCustomer(testCustomerSSNStorage(t))
-	if err := repo.createCustomer(cust, "organization"); err != nil {
+	if err := repo.CreateCustomer(cust, "organization"); err != nil {
 		t.Error(err)
 	}
 
@@ -93,11 +93,13 @@ func TestCustomerSearch__query(t *testing.T) {
 	}
 
 	// Query search
-	query, args := buildSearchQuery(searchParams{
-		Organization: "foo",
-		Query:        "jane doe",
-		Count:        100,
-	})
+	query, args := buildSearchQuery(
+		SearchParams{
+			Organization: "foo",
+			Query:        "jane doe",
+			Count:        100,
+		},
+	)
 	if query != "select customer_id from customers where deleted_at is null and organization = ? and lower(first_name) || \" \" || lower(last_name) LIKE ? order by created_at desc limit ?;" {
 		t.Errorf("unexpected query: %q", query)
 	}
@@ -112,10 +114,12 @@ func TestCustomerSearch__query(t *testing.T) {
 	}
 
 	// Eamil search
-	query, args = buildSearchQuery(searchParams{
-		Organization: "foo",
-		Email:        "jane.doe@moov.io",
-	})
+	query, args = buildSearchQuery(
+		SearchParams{
+			Organization: "foo",
+			Email:        "jane.doe@moov.io",
+		},
+	)
 	if query != "select customer_id from customers where deleted_at is null and organization = ? and lower(email) like ? order by created_at desc limit ?;" {
 		t.Errorf("unexpected query: %q", query)
 	}
@@ -130,12 +134,14 @@ func TestCustomerSearch__query(t *testing.T) {
 	}
 
 	// Query and Eamil saerch
-	query, args = buildSearchQuery(searchParams{
-		Organization: "foo",
-		Query:        "jane doe",
-		Email:        "jane.doe@moov.io",
-		Count:        25,
-	})
+	query, args = buildSearchQuery(
+		SearchParams{
+			Organization: "foo",
+			Query:        "jane doe",
+			Email:        "jane.doe@moov.io",
+			Count:        25,
+		},
+	)
 	if query != "select customer_id from customers where deleted_at is null and organization = ? and lower(first_name) || \" \" || lower(last_name) LIKE ? and lower(email) like ? order by created_at desc limit ?;" {
 		t.Errorf("unexpected query: %q", query)
 	}

--- a/pkg/customers/customers_test.go
+++ b/pkg/customers/customers_test.go
@@ -39,14 +39,14 @@ type testCustomerRepository struct {
 	savedOFACSearchResult *ofacSearchResult
 }
 
-func (r *testCustomerRepository) getCustomer(customerID string) (*client.Customer, error) {
+func (r *testCustomerRepository) GetCustomer(customerID string) (*client.Customer, error) {
 	if r.err != nil {
 		return nil, r.err
 	}
 	return r.customer, nil
 }
 
-func (r *testCustomerRepository) createCustomer(c *client.Customer, organization string) error {
+func (r *testCustomerRepository) CreateCustomer(c *client.Customer, organization string) error {
 	r.createdCustomer = c
 	return r.err
 }
@@ -66,7 +66,7 @@ func (r *testCustomerRepository) updateCustomerStatus(customerID string, status 
 	return r.err
 }
 
-func (r *testCustomerRepository) searchCustomers(params searchParams) ([]*client.Customer, error) {
+func (r *testCustomerRepository) searchCustomers(params SearchParams) ([]*client.Customer, error) {
 	if r.err != nil {
 		return nil, r.err
 	}
@@ -147,7 +147,7 @@ func TestCustomers__GetCustomer(t *testing.T) {
 		LastName:  "Doe",
 		Email:     "jane@example.com",
 	}).asCustomer(testCustomerSSNStorage(t))
-	if err := repo.createCustomer(cust, "organization"); err != nil {
+	if err := repo.CreateCustomer(cust, "organization"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -203,10 +203,10 @@ func TestCustomers__DeleteCustomer(t *testing.T) {
 	}
 	customer, _, _ := cr.asCustomer(testCustomerSSNStorage(t))
 	require.NoError(t,
-		repo.createCustomer(customer, "organization"),
+		repo.CreateCustomer(customer, "organization"),
 	)
 
-	got, err := repo.getCustomer(customer.CustomerID)
+	got, err := repo.GetCustomer(customer.CustomerID)
 	require.NoError(t, err)
 	require.NotNil(t, got)
 
@@ -220,7 +220,7 @@ func TestCustomers__DeleteCustomer(t *testing.T) {
 
 	require.Equal(t, http.StatusNoContent, w.Code)
 	require.Empty(t, w.Body)
-	got, err = repo.getCustomer(customer.CustomerID)
+	got, err = repo.GetCustomer(customer.CustomerID)
 	require.NoError(t, err)
 	require.Nil(t, got)
 }
@@ -232,11 +232,11 @@ func TestCustomerRepository__createCustomer(t *testing.T) {
 			LastName:  "Doe",
 			Email:     "jane@example.com",
 		}).asCustomer(testCustomerSSNStorage(t))
-		if err := repo.createCustomer(cust, "organization"); err != nil {
+		if err := repo.CreateCustomer(cust, "organization"); err != nil {
 			t.Fatal(err)
 		}
 
-		cust, err := repo.getCustomer(cust.CustomerID)
+		cust, err := repo.GetCustomer(cust.CustomerID)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -433,10 +433,10 @@ func TestCustomers__updateCustomer(t *testing.T) {
 	}
 	customer, _, _ := createReq.asCustomer(testCustomerSSNStorage(t))
 	require.NoError(t,
-		repo.createCustomer(customer, "organization"),
+		repo.CreateCustomer(customer, "organization"),
 	)
 
-	_, err := repo.getCustomer(customer.CustomerID)
+	_, err := repo.GetCustomer(customer.CustomerID)
 	require.NoError(t, err)
 
 	router := mux.NewRouter()
@@ -472,7 +472,7 @@ func TestCustomers__updateCustomer(t *testing.T) {
 	require.NoError(t, json.NewDecoder(w.Body).Decode(&got))
 	fmt.Println(w.Body.String())
 
-	want, err := repo.getCustomer(customer.CustomerID)
+	want, err := repo.GetCustomer(customer.CustomerID)
 	require.NoError(t, err)
 
 	got.CreatedAt = want.CreatedAt
@@ -492,7 +492,7 @@ func TestCustomers__repository(t *testing.T) {
 	repo := createTestCustomerRepository(t)
 	defer repo.close()
 
-	cust, err := repo.getCustomer(base.ID())
+	cust, err := repo.GetCustomer(base.ID())
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -521,7 +521,7 @@ func TestCustomers__repository(t *testing.T) {
 			},
 		},
 	}).asCustomer(testCustomerSSNStorage(t))
-	if err := repo.createCustomer(cust, "organization"); err != nil {
+	if err := repo.CreateCustomer(cust, "organization"); err != nil {
 		t.Error(err)
 	}
 	if cust == nil {
@@ -532,7 +532,7 @@ func TestCustomers__repository(t *testing.T) {
 	}
 
 	// read
-	cust, err = repo.getCustomer(cust.CustomerID)
+	cust, err = repo.GetCustomer(cust.CustomerID)
 	if err != nil {
 		t.Error(err)
 	}
@@ -561,7 +561,7 @@ func TestCustomerRepository__delete(t *testing.T) {
 		}
 		cust, _, _ := cr.asCustomer(testCustomerSSNStorage(t))
 		require.NoError(t,
-			repo.createCustomer(cust, "organization"),
+			repo.CreateCustomer(cust, "organization"),
 		)
 
 		customers[i] = &customer{
@@ -625,7 +625,7 @@ func TestCustomerRepository__updateCustomer(t *testing.T) {
 		},
 	}
 	newCust, _, _ := createReq.asCustomer(testCustomerSSNStorage(t))
-	err := repo.createCustomer(newCust, "organization")
+	err := repo.CreateCustomer(newCust, "organization")
 	require.NoError(t, err)
 
 	updateReq := customerRequest{
@@ -668,7 +668,7 @@ func TestCustomerRepository__updateCustomerStatus(t *testing.T) {
 		LastName:  "Doe",
 		Email:     "jane@example.com",
 	}).asCustomer(testCustomerSSNStorage(t))
-	if err := repo.createCustomer(cust, "organization"); err != nil {
+	if err := repo.CreateCustomer(cust, "organization"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -678,7 +678,7 @@ func TestCustomerRepository__updateCustomerStatus(t *testing.T) {
 	}
 
 	// read the status back
-	customer, err := repo.getCustomer(cust.CustomerID)
+	customer, err := repo.GetCustomer(cust.CustomerID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -696,7 +696,7 @@ func TestCustomersRepository__addCustomerAddress(t *testing.T) {
 		LastName:  "Doe",
 		Email:     "jane@example.com",
 	}).asCustomer(testCustomerSSNStorage(t))
-	if err := repo.createCustomer(cust, "organization"); err != nil {
+	if err := repo.CreateCustomer(cust, "organization"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -707,12 +707,13 @@ func TestCustomersRepository__addCustomerAddress(t *testing.T) {
 		State:      "CA",
 		PostalCode: "90210",
 		Country:    "US",
-	}); err != nil {
+	},
+	); err != nil {
 		t.Fatal(err)
 	}
 
 	// re-read
-	cust, err := repo.getCustomer(cust.CustomerID)
+	cust, err := repo.GetCustomer(cust.CustomerID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -733,7 +734,7 @@ func TestCustomers__replaceCustomerMetadata(t *testing.T) {
 		LastName:  "Doe",
 		Email:     "jane@example.com",
 	}).asCustomer(testCustomerSSNStorage(t))
-	if err := repo.createCustomer(cust, "organization"); err != nil {
+	if err := repo.CreateCustomer(cust, "organization"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -788,7 +789,7 @@ func TestCustomers__replaceCustomerMetadataInvalid(t *testing.T) {
 		LastName:  "Doe",
 		Email:     "jane@example.com",
 	}).asCustomer(testCustomerSSNStorage(t))
-	if err := repo.createCustomer(cust, "organization"); err != nil {
+	if err := repo.CreateCustomer(cust, "organization"); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/reports/router.go
+++ b/pkg/reports/router.go
@@ -1,0 +1,81 @@
+package reports
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/go-kit/kit/log"
+	"github.com/gorilla/mux"
+	moovhttp "github.com/moov-io/base/http"
+
+	"github.com/moov-io/customers/pkg/accounts"
+	"github.com/moov-io/customers/pkg/client"
+	"github.com/moov-io/customers/pkg/customers"
+	"github.com/moov-io/customers/pkg/route"
+)
+
+func AddRoutes(
+	logger log.Logger,
+	r *mux.Router,
+	customerRepo customers.CustomerRepository,
+	accountRepo accounts.Repository,
+) {
+	r.Methods("GET").Path("/reports/accounts").HandlerFunc(getCustomerAccounts(logger, customerRepo, accountRepo))
+}
+
+type CustomerAccount struct {
+	Customer *client.Customer `json:"customer"`
+	Account  *client.Account  `json:"account"`
+}
+
+func getCustomerAccounts(
+	logger log.Logger,
+	customerRepo customers.CustomerRepository,
+	accountRepo accounts.Repository,
+) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w = route.Responder(logger, w, r)
+		requestID := moovhttp.GetRequestID(r)
+
+		accountIDsInput := r.URL.Query().Get("accountIDs")
+		accountIDsInput = strings.TrimSpace(accountIDsInput)
+		accountIDs := strings.Split(accountIDsInput, ",")
+
+		limit := 25
+		if len(accountIDs) > limit {
+			moovhttp.Problem(w, fmt.Errorf("exceeded limit of %d accountIDs, found %d", limit, len(accountIDs)))
+			return
+		}
+
+		allAccounts, err := accountRepo.GetCustomerAccountsByIDs(accountIDs)
+		if err != nil {
+			logger.Log("customers", "error getting customers' accounts", "error", err, "requestID", requestID)
+			moovhttp.Problem(w, err)
+			return
+		}
+
+		results := make([]*client.ReportAccountResponse, 0)
+		for _, acc := range allAccounts {
+			cust, err := customerRepo.GetCustomer(acc.CustomerID)
+			if err != nil {
+				logger.Log("customers", "error getting customer", "error", err, "requestID", requestID)
+				moovhttp.Problem(w, err)
+				return
+			}
+			results = append(results, &client.ReportAccountResponse{
+				Customer: *cust,
+				Account:  *acc,
+			})
+		}
+
+		err = json.NewEncoder(w).Encode(results)
+		if err != nil {
+			moovhttp.Problem(w, err)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+	}
+}


### PR DESCRIPTION
Adds the endpoint /reports/accounts?accountIDs={...} which returns a list of objects that include customer and account information.

Fixes #196