### PR TITLE
Enable searching customers by their IDs and optimize # of database queries

### DIFF
--- a/api/client.yaml
+++ b/api/client.yaml
@@ -206,8 +206,14 @@ paths:
             type: string
         - name: count
           in: query
-          description: Optional parameter for searching for customers by specifying the amount to return
+          description: Optional parameter for searching by specifying the amount to return
           example: 20
+          schema:
+            type: string
+        - name: customerIDs
+          in: query
+          description: Optional parameter for searching by customers' IDs
+          example: e210a9d6-d755-4455-9bd2-9577ea7e1081,970ef15d-a4e1-473f-b5d7-da38163b0ba3
           schema:
             type: string
       responses:

--- a/pkg/client/api/openapi.yaml
+++ b/pkg/client/api/openapi.yaml
@@ -230,12 +230,21 @@ paths:
         schema:
           type: string
         style: form
-      - description: Optional parameter for searching for customers by specifying
-          the amount to return
+      - description: Optional parameter for searching by specifying the amount to
+          return
         example: 20
         explode: true
         in: query
         name: count
+        required: false
+        schema:
+          type: string
+        style: form
+      - description: Optional parameter for searching by customers' IDs
+        example: e210a9d6-d755-4455-9bd2-9577ea7e1081,970ef15d-a4e1-473f-b5d7-da38163b0ba3
+        explode: true
+        in: query
+        name: customerIDs
         required: false
         schema:
           type: string

--- a/pkg/client/api_customers.go
+++ b/pkg/client/api_customers.go
@@ -2517,12 +2517,13 @@ func (a *CustomersApiService) ReplaceCustomerMetadata(ctx _context.Context, cust
 
 // SearchCustomersOpts Optional parameters for the method 'SearchCustomers'
 type SearchCustomersOpts struct {
-	Query  optional.String
-	Email  optional.String
-	Status optional.String
-	Type_  optional.String
-	Skip   optional.String
-	Count  optional.String
+	Query       optional.String
+	Email       optional.String
+	Status      optional.String
+	Type_       optional.String
+	Skip        optional.String
+	Count       optional.String
+	CustomerIDs optional.String
 }
 
 /*
@@ -2535,7 +2536,8 @@ Search for customers using different filter parameters
  * @param "Status" (optional.String) -  Optional parameter for searching by customer status
  * @param "Type_" (optional.String) -  Optional parameter for searching by customer type
  * @param "Skip" (optional.String) -  Optional parameter for searching for customers by skipping over an initial group
- * @param "Count" (optional.String) -  Optional parameter for searching for customers by specifying the amount to return
+ * @param "Count" (optional.String) -  Optional parameter for searching by specifying the amount to return
+ * @param "CustomerIDs" (optional.String) -  Optional parameter for searching by customers' IDs
 @return []Customer
 */
 func (a *CustomersApiService) SearchCustomers(ctx _context.Context, localVarOptionals *SearchCustomersOpts) ([]Customer, *_nethttp.Response, error) {
@@ -2571,6 +2573,9 @@ func (a *CustomersApiService) SearchCustomers(ctx _context.Context, localVarOpti
 	}
 	if localVarOptionals != nil && localVarOptionals.Count.IsSet() {
 		localVarQueryParams.Add("count", parameterToString(localVarOptionals.Count.Value(), ""))
+	}
+	if localVarOptionals != nil && localVarOptionals.CustomerIDs.IsSet() {
+		localVarQueryParams.Add("customerIDs", parameterToString(localVarOptionals.CustomerIDs.Value(), ""))
 	}
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}

--- a/pkg/client/docs/CustomersApi.md
+++ b/pkg/client/docs/CustomersApi.md
@@ -1218,7 +1218,8 @@ Name | Type | Description  | Notes
  **status** | **optional.String**| Optional parameter for searching by customer status | 
  **type_** | **optional.String**| Optional parameter for searching by customer type | 
  **skip** | **optional.String**| Optional parameter for searching for customers by skipping over an initial group | 
- **count** | **optional.String**| Optional parameter for searching for customers by specifying the amount to return | 
+ **count** | **optional.String**| Optional parameter for searching by specifying the amount to return | 
+ **customerIDs** | **optional.String**| Optional parameter for searching by customers&#39; IDs | 
 
 ### Return type
 

--- a/pkg/customers/customer_search.go
+++ b/pkg/customers/customer_search.go
@@ -5,6 +5,7 @@
 package customers
 
 import (
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -13,6 +14,7 @@ import (
 	moovhttp "github.com/moov-io/base/http"
 
 	"github.com/moov-io/base/log"
+
 	"github.com/moov-io/customers/pkg/client"
 	"github.com/moov-io/customers/pkg/route"
 )
@@ -26,7 +28,7 @@ func searchCustomers(logger log.Logger, repo CustomerRepository) http.HandlerFun
 			return
 		}
 
-		params, err := readSearchParams(r)
+		params, err := parseSearchParams(r)
 		if err != nil {
 			moovhttp.Problem(w, err)
 			return
@@ -55,15 +57,25 @@ type SearchParams struct {
 	Type         string
 	Skip         int64
 	Count        int64
+	CustomerIDs  []string
 }
 
-func readSearchParams(r *http.Request) (SearchParams, error) {
-	params := SearchParams{
-		Query:  strings.ToLower(strings.TrimSpace(r.URL.Query().Get("query"))),
-		Email:  strings.ToLower(strings.TrimSpace(r.URL.Query().Get("email"))),
-		Status: strings.ToLower(strings.TrimSpace(r.URL.Query().Get("status"))),
-		Type:   strings.ToLower(strings.TrimSpace(r.URL.Query().Get("type"))),
+func parseSearchParams(r *http.Request) (SearchParams, error) {
+	queryParams := r.URL.Query()
+	getQueryParam := func(key string) string {
+		return strings.ToLower(strings.TrimSpace(queryParams.Get(key)))
 	}
+	params := SearchParams{
+		Query:  getQueryParam("query"),
+		Email:  getQueryParam("email"),
+		Status: getQueryParam("status"),
+		Type:   getQueryParam("type"),
+	}
+	customerIDsInput := getQueryParam("customerIDs")
+	if customerIDsInput != "" {
+		params.CustomerIDs = strings.Split(customerIDsInput, ",")
+	}
+
 	skip, count, exists, err := moovhttp.GetSkipAndCount(r)
 	if exists && err != nil {
 		return params, err
@@ -84,54 +96,103 @@ func (r *sqlCustomerRepository) searchCustomers(params SearchParams) ([]*client.
 	}
 	defer stmt.Close()
 
-	var customerIDs []string
 	customers := make([]*client.Customer, 0)
-
-	// grab customerIDs
 	rows, err := stmt.Query(args...)
 	if err != nil {
-		return customers, err
+		return nil, err
 	}
 	for rows.Next() {
-		var customerID string
-		if err := rows.Scan(&customerID); err == nil {
-			customerIDs = append(customerIDs, customerID)
-		} else {
-			return customers, err
+		var c client.Customer
+		var birthDate *string
+		err := rows.Scan(
+			&c.CustomerID,
+			&c.FirstName,
+			&c.MiddleName,
+			&c.LastName,
+			&c.NickName,
+			&c.Suffix,
+			&c.Type,
+			&birthDate,
+			&c.Status,
+			&c.Email,
+			&c.CreatedAt,
+			&c.LastModified,
+		)
+		if err != nil {
+			return nil, err
 		}
+		customers = append(customers, &c)
 	}
 
-	// Read each Customer
-	for i := range customerIDs {
-		cust, err := r.GetCustomer(customerIDs[i])
-		if err != nil {
-			return customers, fmt.Errorf("search: customerID=%s error=%v", customerIDs[i], err)
-		}
-		customers = append(customers, cust)
+	if len(customers) == 0 {
+		return customers, nil
 	}
+
+	var customerIDs []string
+	for _, c := range customers {
+		customerIDs = append(customerIDs, c.CustomerID)
+	}
+
+	phonesByCustomerID, err := r.getPhones(customerIDs)
+	if err != nil {
+		return nil, fmt.Errorf("fetching customer phones: %v", err)
+	}
+	addressesByCustomerID, err := r.getAddresses(customerIDs)
+	if err != nil {
+		return nil, fmt.Errorf("fetching customer addresses: %v", err)
+	}
+	metadataByCustomerID, err := r.getMetadata(customerIDs)
+	if err != nil {
+		return nil, fmt.Errorf("fetching customer metadata: %v", err)
+	}
+
+	for _, c := range customers {
+		c.Phones = phonesByCustomerID[c.CustomerID]
+		c.Addresses = addressesByCustomerID[c.CustomerID]
+		c.Metadata = metadataByCustomerID[c.CustomerID].Metadata
+	}
+
 	return customers, nil
 }
 
 func buildSearchQuery(params SearchParams) (string, []interface{}) {
 	var args []interface{}
-	query := `select customer_id from customers where deleted_at is null and organization = ?`
-	args = append(args, params.Organization)
-	if params.Query != "" {
-		query += " and lower(first_name) || \" \" || lower(last_name) LIKE ?"
-		args = append(args, "%"+params.Query+"%")
+	query := `select customer_id, first_name, middle_name, last_name, nick_name, suffix, type, birth_date, status, email, created_at, last_modified
+from customers where deleted_at is null`
+
+	if params.Organization != "" {
+		query += " and organization = ?"
+		args = append(args, params.Organization)
 	}
+
+	if params.Query != "" {
+		// warning: this will ONLY work for MySQL
+		query += " and lower(concat(first_name,' ', last_name)) LIKE ?"
+		args = append(args, fmt.Sprintf("%%%s%%", params.Query))
+	}
+
 	if params.Email != "" {
 		query += " and lower(email) like ?"
 		args = append(args, "%"+params.Email)
 	}
+
 	if params.Status != "" {
 		query += " and status like ?"
 		args = append(args, "%"+params.Status)
 	}
+
 	if params.Type != "" {
 		query += " and type like ?"
 		args = append(args, "%"+params.Type)
 	}
+
+	if len(params.CustomerIDs) > 0 {
+		query += fmt.Sprintf(" and customer_id in (?%s)", strings.Repeat(",?", len(params.CustomerIDs)-1))
+		for _, id := range params.CustomerIDs {
+			args = append(args, id)
+		}
+	}
+
 	query += " order by created_at desc limit ?"
 	args = append(args, fmt.Sprintf("%d", params.Count))
 
@@ -141,4 +202,117 @@ func buildSearchQuery(params SearchParams) (string, []interface{}) {
 	}
 	query += ";"
 	return query, args
+}
+
+func (r *sqlCustomerRepository) getPhones(customerIDs []string) (map[string][]client.Phone, error) {
+	query := fmt.Sprintf(
+		"select customer_id, number, valid, type from customers_phones where customer_id in (?%s)",
+		strings.Repeat(",?", len(customerIDs)-1),
+	)
+
+	rows, err := r.queryRowsByCustomerIDs(query, customerIDs)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	ret := make(map[string][]client.Phone)
+	for rows.Next() {
+		var p client.Phone
+		var customerID string
+		err := rows.Scan(
+			&customerID,
+			&p.Number,
+			&p.Valid,
+			&p.Type,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("scanning row: %v", err)
+		}
+		ret[customerID] = append(ret[customerID], p)
+	}
+
+	return ret, nil
+}
+
+func (r *sqlCustomerRepository) getAddresses(customerIDs []string) (map[string][]client.CustomerAddress, error) {
+	query := fmt.Sprintf(
+		"select customer_id, address_id, type, address1, address2, city, state, postal_code, country, validated from customers_addresses where customer_id in (?%s) and deleted_at is null;",
+		strings.Repeat(",?", len(customerIDs)-1),
+	)
+	rows, err := r.queryRowsByCustomerIDs(query, customerIDs)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	ret := make(map[string][]client.CustomerAddress)
+	for rows.Next() {
+		var a client.CustomerAddress
+		var customerID string
+		if err := rows.Scan(
+			&customerID,
+			&a.AddressID,
+			&a.Type,
+			&a.Address1,
+			&a.Address2,
+			&a.City,
+			&a.State,
+			&a.PostalCode,
+			&a.Country,
+			&a.Validated,
+		); err != nil {
+			return nil, fmt.Errorf("scanning row: %v", err)
+		}
+		ret[customerID] = append(ret[customerID], a)
+	}
+
+	return ret, nil
+}
+
+func (r *sqlCustomerRepository) getMetadata(customerIDs []string) (map[string]client.CustomerMetadata, error) {
+	query := fmt.Sprintf(
+		"select customer_id, meta_key, meta_value from customer_metadata where customer_id in (?%s);",
+		strings.Repeat(",?", len(customerIDs)-1),
+	)
+	rows, err := r.queryRowsByCustomerIDs(query, customerIDs)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	ret := make(map[string]client.CustomerMetadata)
+	for rows.Next() {
+		m := client.CustomerMetadata{
+			Metadata: make(map[string]string),
+		}
+		var customerID string
+		var k, v string
+		if err := rows.Scan(&customerID, &k, &v); err != nil {
+			return nil, fmt.Errorf("scanning row: %v", err)
+		}
+		m.Metadata[k] = v
+		ret[customerID] = m
+	}
+	return ret, nil
+}
+
+func (r *sqlCustomerRepository) queryRowsByCustomerIDs(query string, customerIDs []string) (*sql.Rows, error) {
+	stmt, err := r.db.Prepare(query)
+	if err != nil {
+		return nil, fmt.Errorf("preparing query: %v", err)
+	}
+	defer stmt.Close()
+
+	var args []interface{}
+	for _, id := range customerIDs {
+		args = append(args, id)
+	}
+
+	rows, err := stmt.Query(args...)
+	if err != nil {
+		return nil, fmt.Errorf("executing query: %v", err)
+	}
+
+	return rows, nil
 }

--- a/pkg/customers/customers.go
+++ b/pkg/customers/customers.go
@@ -400,7 +400,6 @@ type CustomerRepository interface {
 
 	searchCustomers(params SearchParams) ([]*client.Customer, error)
 
-	getCustomerMetadata(customerID string) (map[string]string, error)
 	replaceCustomerMetadata(customerID string, metadata map[string]string) error
 
 	addCustomerAddress(customerID string, address address) error
@@ -486,6 +485,7 @@ func (r *sqlCustomerRepository) updateCustomer(c *client.Customer, organization 
 	if err != nil {
 		return err
 	}
+	defer tx.Rollback()
 
 	query := `update customers set first_name = ?, middle_name = ?, last_name = ?, nick_name = ?, suffix = ?, type = ?, birth_date = ?, status = ?, email =?,
 	last_modified = ?,
@@ -528,17 +528,39 @@ func (r *sqlCustomerRepository) updateCustomer(c *client.Customer, organization 
 }
 
 func (r *sqlCustomerRepository) updatePhonesByCustomerID(tx *sql.Tx, customerID string, phones []client.Phone) error {
-	query := `replace into customers_phones (customer_id, number, valid, type) values (?, ?, ?, ?);`
-	stmt, err := tx.Prepare(query)
+	deleteQuery := `delete from customers_phones where customer_id = ?`
+	var args []interface{}
+	args = append(args, customerID)
+	if len(phones) > 0 {
+		deleteQuery = fmt.Sprintf("%s and number not in (?%s)", deleteQuery, strings.Repeat(",?", len(phones)-1))
+		for _, p := range phones {
+			args = append(args, p.Number)
+		}
+	}
+	deleteQuery = fmt.Sprintf("%s;", deleteQuery)
+
+	stmt, err := tx.Prepare(deleteQuery)
 	if err != nil {
-		return fmt.Errorf("preparing tx update on customers_phones err=%v | rollback=%v", err, tx.Rollback())
+		return fmt.Errorf("preparing query: %v", err)
+	}
+	defer stmt.Close()
+
+	_, err = stmt.Exec(args...)
+	if err != nil {
+		return fmt.Errorf("executing query: %v", err)
+	}
+
+	replaceQuery := `replace into customers_phones (customer_id, number, valid, type) values (?, ?, ?, ?);`
+	stmt, err = tx.Prepare(replaceQuery)
+	if err != nil {
+		return fmt.Errorf("preparing query: %v", err)
 	}
 	defer stmt.Close()
 
 	for _, phone := range phones {
 		_, err := stmt.Exec(customerID, phone.Number, phone.Valid, phone.Type)
 		if err != nil {
-			return fmt.Errorf("executing update on customers_phones err=%v | rollback=%v", err, tx.Rollback())
+			return fmt.Errorf("executing update on customer's phone: %v", err)
 		}
 	}
 
@@ -546,117 +568,60 @@ func (r *sqlCustomerRepository) updatePhonesByCustomerID(tx *sql.Tx, customerID 
 }
 
 func (r *sqlCustomerRepository) updateAddressesByCustomerID(tx *sql.Tx, customerID string, addresses []client.CustomerAddress) error {
-	query := `replace into customers_addresses(address_id, customer_id, type, address1, address2, city, state, postal_code, country, validated) values (?, ?, ?, ?, ?, ?, ?, ?,
-	?, ?);`
-	stmt, err := tx.Prepare(query)
+	deleteQuery := `delete from customers_addresses where customer_id = ?`
+	var args []interface{}
+	args = append(args, customerID)
+	if len(addresses) > 0 {
+		deleteQuery = fmt.Sprintf("%s and address1 not in (?%s)", deleteQuery, strings.Repeat(",?", len(addresses)-1))
+		for _, a := range addresses {
+			args = append(args, a.Address1)
+		}
+	}
+	deleteQuery = fmt.Sprintf("%s;", deleteQuery)
+
+	stmt, err := tx.Prepare(deleteQuery)
 	if err != nil {
-		return fmt.Errorf("preparing tx on customers_addresses err=%v | rollback=%v", err, tx.Rollback())
+		return fmt.Errorf("preparing query: %v", err)
+	}
+	defer stmt.Close()
+
+	_, err = stmt.Exec(args...)
+	if err != nil {
+		panic(err)
+	}
+
+	replaceQuery := `replace into customers_addresses(address_id, customer_id, type, address1, address2, city, state, postal_code, country, validated) values (?, ?, ?, ?, ?, ?, ?, ?,
+	?, ?);`
+	stmt, err = tx.Prepare(replaceQuery)
+	if err != nil {
+		return fmt.Errorf("preparing query: %v", err)
 	}
 	defer stmt.Close()
 
 	for _, addr := range addresses {
 		_, err := stmt.Exec(addr.AddressID, customerID, addr.Type, addr.Address1, addr.Address2, addr.City, addr.State, addr.PostalCode, addr.Country, addr.Validated)
 		if err != nil {
-			return fmt.Errorf("executing update on customers_addresses err=%v | rollback=%v", err, tx.Rollback())
+			return fmt.Errorf("executing query: %v", err)
 		}
 	}
+
 	return nil
 }
 
 func (r *sqlCustomerRepository) GetCustomer(customerID string) (*client.Customer, error) {
-	query := `select first_name, middle_name, last_name, nick_name, suffix, type, birth_date, status, email, created_at, last_modified from customers where customer_id = ? and deleted_at is null limit 1;`
-	stmt, err := r.db.Prepare(query)
+	custs, err := r.searchCustomers(SearchParams{
+		Count:       1,
+		CustomerIDs: []string{customerID},
+	})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("getting customer: %v", err)
 	}
 
-	row := stmt.QueryRow(customerID)
-
-	var birthDate *string
-	var cust client.Customer
-	cust.CustomerID = customerID
-	err = row.Scan(&cust.FirstName, &cust.MiddleName, &cust.LastName, &cust.NickName, &cust.Suffix, &cust.Type, &birthDate, &cust.Status, &cust.Email, &cust.CreatedAt,
-		&cust.LastModified)
-	stmt.Close()
-	if err != nil && !strings.Contains(err.Error(), "no rows in result set") {
-		return nil, fmt.Errorf("GetCustomer: %v", err)
-	}
-	if cust.FirstName == "" {
-		return nil, nil // not found
-	}
-	if birthDate != nil {
-		cust.BirthDate = *birthDate
+	if len(custs) == 0 {
+		return nil, errors.New("customer not found")
 	}
 
-	phones, err := r.readPhones(customerID)
-	if err != nil {
-		return nil, fmt.Errorf("GetCustomer: readPhones: %v", err)
-	}
-	cust.Phones = phones
-
-	addresses, err := r.readAddresses(customerID)
-	if err != nil {
-		return nil, fmt.Errorf("GetCustomer: readAddresses: %v", err)
-	}
-	cust.Addresses = addresses
-
-	metadata, err := r.getCustomerMetadata(customerID)
-	if err != nil {
-		return nil, fmt.Errorf("GetCustomer: getCustomerMetadata: %v", err)
-	}
-	cust.Metadata = metadata
-
-	return &cust, nil
-}
-
-func (r *sqlCustomerRepository) readPhones(customerID string) ([]client.Phone, error) {
-	query := `select number, valid, type from customers_phones where customer_id = ?;`
-	stmt, err := r.db.Prepare(query)
-	if err != nil {
-		return nil, fmt.Errorf("GetCustomer: prepare customers_phones: err=%v", err)
-	}
-	defer stmt.Close()
-
-	rows, err := stmt.Query(customerID)
-	if err != nil {
-		return nil, fmt.Errorf("GetCustomer: query customers_phones: err=%v", err)
-	}
-	defer rows.Close()
-
-	var phones []client.Phone
-	for rows.Next() {
-		var p client.Phone
-		if err := rows.Scan(&p.Number, &p.Valid, &p.Type); err != nil {
-			return nil, fmt.Errorf("GetCustomer: scan customers_phones: err=%v", err)
-		}
-		phones = append(phones, p)
-	}
-	return phones, rows.Err()
-}
-
-func (r *sqlCustomerRepository) readAddresses(customerID string) ([]client.CustomerAddress, error) {
-	query := `select address_id, type, address1, address2, city, state, postal_code, country, validated from customers_addresses where customer_id = ? and deleted_at is null;`
-	stmt, err := r.db.Prepare(query)
-	if err != nil {
-		return nil, fmt.Errorf("readAddresses: prepare customers_addresses: err=%v", err)
-	}
-	defer stmt.Close()
-
-	rows, err := stmt.Query(customerID)
-	if err != nil {
-		return nil, fmt.Errorf("readAddresses: query customers_addresses: err=%v", err)
-	}
-	defer rows.Close()
-
-	var adds []client.CustomerAddress
-	for rows.Next() {
-		var a client.CustomerAddress
-		if err := rows.Scan(&a.AddressID, &a.Type, &a.Address1, &a.Address2, &a.City, &a.State, &a.PostalCode, &a.Country, &a.Validated); err != nil {
-			return nil, fmt.Errorf("readAddresses: scan customers_addresses: err=%v", err)
-		}
-		adds = append(adds, a)
-	}
-	return adds, rows.Err()
+	return custs[0], nil
 }
 
 func (r *sqlCustomerRepository) updateCustomerStatus(customerID string, status client.CustomerStatus, comment string) error {
@@ -688,32 +653,6 @@ func (r *sqlCustomerRepository) updateCustomerStatus(customerID string, status c
 		return fmt.Errorf("updateCustomerStatus: insert status exec: %v", err)
 	}
 	return tx.Commit()
-}
-
-func (r *sqlCustomerRepository) getCustomerMetadata(customerID string) (map[string]string, error) {
-	out := make(map[string]string)
-
-	query := `select meta_key, meta_value from customer_metadata where customer_id = ?;`
-	stmt, err := r.db.Prepare(query)
-	if err != nil {
-		return out, fmt.Errorf("getCustomerMetadata: prepare: %v", err)
-	}
-	defer stmt.Close()
-
-	rows, err := stmt.Query(customerID)
-	if err != nil {
-		return out, fmt.Errorf("getCustomerMetadata: query: %v", err)
-	}
-	defer rows.Close()
-
-	for rows.Next() {
-		key, value := "", ""
-		if err := rows.Scan(&key, &value); err != nil {
-			return out, fmt.Errorf("getCustomerMetadata: scan: %v", err)
-		}
-		out[key] = value
-	}
-	return out, nil
 }
 
 func (r *sqlCustomerRepository) replaceCustomerMetadata(customerID string, metadata map[string]string) error {


### PR DESCRIPTION
This PR makes two main changes:

1. Adds the ability to search by customerIDs: `GET /customers?customerIDs=id_1,id_2`

2. Reduces the number of database queries triggered by `GET /customers`
A call to `GET /customers` that matches `n=25` customers would trigger `~100 or n*4` database queries:
`searchCustomers` would call `getCustomer()` `n` times 
   - each call to `getCustomer()` would also trigger 3 additional db queries to fetch the customer's addresses, phones, and metadata.
Thus, `n * ( getCustomer() + getAddresses() + getPhones() + getMetadata() ) -> 25 * (1+1+1+1) = 100` 



Fixes #220 #216